### PR TITLE
Add web module boilerplate to simplify the HTML setup

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -35,6 +35,7 @@
         {Credo.Check.Refactor.CaseTrivialMatches},
         {Credo.Check.Refactor.CondStatements},
         {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.MapInto, false},
         {Credo.Check.Refactor.MatchInCondition},
         {Credo.Check.Refactor.PipeChainStart, excluded_argument_types: ~w(atom binary fn keyword)a, excluded_functions: ~w(from)},
         {Credo.Check.Refactor.CyclomaticComplexity},

--- a/.env.dev
+++ b/.env.dev
@@ -31,9 +31,9 @@ BASIC_AUTH_PASSWORD=
 # CSS and JavaScript). We often use these variables to configure a CDN that
 # will cache static files once they have been served by the Phoenix
 # application.
-STATIC_URL_SCHEME=
-STATIC_URL_HOST=
-STATIC_URL_PORT=
+# STATIC_URL_SCHEME=
+# STATIC_URL_HOST=
+# STATIC_URL_PORT=
 
 # OTP configuration
 ERLANG_COOKIE= # Generate with `mix phx.gen.secret`

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,9 +4,9 @@ use Mix.Config
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   http: [port: 4001],
   server: false,
-  secret_key_base: "test",
+  secret_key_base: "G0ieeRljoXGzSDPRrYc2q4ADyNHCwxNOkw7YpPNMa+JgP9iGgJKT4K96Bw/Mf/pd",
   session_key: "test",
-  signing_salt: "test",
+  signing_salt: "qh+vmMHsOqcjKF3TSSIsghwt2go48m2+IQ+kMTOB3BrSysSr7D4a21uAtt4yp4wn",
   static_url: [
     scheme: "https",
     host: "example.com",

--- a/lib/elixir_boilerplate_web/errors/helpers.ex
+++ b/lib/elixir_boilerplate_web/errors/helpers.ex
@@ -1,0 +1,43 @@
+defmodule ElixirBoilerplateWeb.Errors.Helpers do
+  @moduledoc """
+  Conveniences for translating and building error messages.
+  """
+  use Phoenix.HTML
+
+  @doc """
+  Generates tag for inlined form input errors.
+  """
+  def error_tag(form, field) do
+    Enum.map(Keyword.get_values(form.errors, field), fn error ->
+      content_tag(:span, translate_error(error))
+    end)
+  end
+
+  @doc """
+  Translates an error message using gettext.
+  """
+  def translate_error({msg, opts}) do
+    # When using gettext, we typically pass the strings we want
+    # to translate as a static argument:
+    #
+    #     # Translate "is invalid" in the "errors" domain
+    #     dgettext("errors", "is invalid")
+    #
+    #     # Translate the number of files with plural rules
+    #     dngettext("errors", "1 file", "%{count} files", count)
+    #
+    # Because the error messages we show in our forms and APIs
+    # are defined inside Ecto, we need to translate them dynamically.
+    # This requires us to call the Gettext module passing our gettext
+    # backend as first argument.
+    #
+    # Note we use the "errors" domain, which means translations
+    # should be written to the errors.po file. The :count option is
+    # set by Ecto and indicates we should also apply plural rules.
+    if count = opts[:count] do
+      Gettext.dngettext(ElixirBoilerplateWeb.Gettext, "errors", msg, msg, count, opts)
+    else
+      Gettext.dgettext(ElixirBoilerplateWeb.Gettext, "errors", msg, opts)
+    end
+  end
+end

--- a/lib/elixir_boilerplate_web/home/controller.ex
+++ b/lib/elixir_boilerplate_web/home/controller.ex
@@ -1,0 +1,12 @@
+defmodule ElixirBoilerplateWeb.Home.Controller do
+  use Phoenix.Controller
+
+  import ElixirBoilerplate.Gettext
+
+  plug(:put_view, ElixirBoilerplateWeb.Home.View)
+
+  @spec index(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def index(conn, _) do
+    render(conn, "index.html", health: dgettext("health", "ok"))
+  end
+end

--- a/lib/elixir_boilerplate_web/home/templates/index.html.eex
+++ b/lib/elixir_boilerplate_web/home/templates/index.html.eex
@@ -1,0 +1,10 @@
+<div align="center">
+  <br />
+  <img src="https://user-images.githubusercontent.com/11348/52080254-520cb580-2565-11e9-8c21-156cf0b7bcf3.png" width="500" />
+  <p><br />This repository is the stable base upon which we build our Elixir projects at Mirego.<br />We want to share it with the world so you can build awesome Elixir applications too.</p>
+
+  <div>
+    <strong>Health:</strong>
+    <%= @health %>
+  </div>
+</div>

--- a/lib/elixir_boilerplate_web/home/view.ex
+++ b/lib/elixir_boilerplate_web/home/view.ex
@@ -1,0 +1,3 @@
+defmodule ElixirBoilerplateWeb.Home.View do
+  use Phoenix.View, root: "lib/elixir_boilerplate_web", path: "home/templates", namespace: ElixirBoilerplateWeb
+end

--- a/lib/elixir_boilerplate_web/layouts/templates/app.html.eex
+++ b/lib/elixir_boilerplate_web/layouts/templates/app.html.eex
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
+    <%= csrf_meta_tag() %>
+  </head>
+
+  <body>
+    <main role="main">
+      <p role="alert"><%= get_flash(@conn, :info) %></p>
+      <p role="alert"><%= get_flash(@conn, :error) %></p>
+
+      <%= render @view_module, @view_template, assigns %>
+    </main>
+
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+  </body>
+</html>

--- a/lib/elixir_boilerplate_web/layouts/templates/app.html.eex
+++ b/lib/elixir_boilerplate_web/layouts/templates/app.html.eex
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="<%= Routes.static_url(@conn, "/css/app.css") %>" />
     <%= csrf_meta_tag() %>
   </head>
 
@@ -13,9 +13,9 @@
       <p role="alert"><%= get_flash(@conn, :info) %></p>
       <p role="alert"><%= get_flash(@conn, :error) %></p>
 
-      <%= render @view_module, @view_template, assigns %>
+      <%= render(@view_module, @view_template, assigns) %>
     </main>
 
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+    <script type="text/javascript" src="<%= Routes.static_url(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/lib/elixir_boilerplate_web/layouts/view.ex
+++ b/lib/elixir_boilerplate_web/layouts/view.ex
@@ -1,0 +1,8 @@
+defmodule ElixirBoilerplateWeb.Layouts.View do
+  use Phoenix.View, root: "lib/elixir_boilerplate_web", path: "layouts/templates", namespace: ElixirBoilerplateWeb
+  use Phoenix.HTML
+
+  import Phoenix.Controller, only: [get_flash: 2]
+
+  alias ElixirBoilerplateWeb.Router.Helpers, as: Routes
+end

--- a/lib/elixir_boilerplate_web/router.ex
+++ b/lib/elixir_boilerplate_web/router.ex
@@ -19,7 +19,7 @@ defmodule ElixirBoilerplateWeb.Router do
   scope "/", ElixirBoilerplateWeb do
     pipe_through(:api)
 
-    get("/health", Health.Controller, :index, as: :api_health)
+    get("/health", Health.Controller, :index, as: :health)
   end
 
   scope "/", ElixirBoilerplateWeb do

--- a/lib/elixir_boilerplate_web/router.ex
+++ b/lib/elixir_boilerplate_web/router.ex
@@ -7,9 +7,24 @@ defmodule ElixirBoilerplateWeb.Router do
     plug(:accepts, ["json"])
   end
 
+  pipeline :browser do
+    plug(:accepts, ["html", "json"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
+    plug(:put_layout, {ElixirBoilerplateWeb.Layouts.View, :app})
+  end
+
   scope "/", ElixirBoilerplateWeb do
     pipe_through(:api)
 
-    get("/health", Health.Controller, :index)
+    get("/health", Health.Controller, :index, as: :api_health)
+  end
+
+  scope "/", ElixirBoilerplateWeb do
+    pipe_through(:browser)
+
+    get("/", Home.Controller, :index, as: :home)
   end
 end

--- a/test/elixir_boilerplate_web/home/controller_test.exs
+++ b/test/elixir_boilerplate_web/home/controller_test.exs
@@ -1,0 +1,8 @@
+defmodule ElixirBoilerplateWeb.Home.ControllerTest do
+  use ElixirBoilerplateWeb.ConnCase
+
+  test "GET /", %{conn: conn} do
+    conn = get(conn, "/")
+    assert html_response(conn, 200) =~ "The system looks OK."
+  end
+end


### PR DESCRIPTION
- `config/test.exs` changes were made to prevent this error:

```elixir
** (ArgumentError) cookie store expects conn.secret_key_base to be at least 64 bytes
```

used when fetching session in the new `browser` pipeline.

- The `{Credo.Check.Refactor.MapInto, false},` is to prevent Elixir 1.8 warning 😉
- The `ElixirBoilerplateWeb.Errors.Helpers` module is used in forms generated by `phx.gen.html` so it is useful to have it. (It is also used in forms we create from scratch so it’s in every projects)

The final result for a fresh clone will be:

![image](https://user-images.githubusercontent.com/464900/54564494-4f91de00-49a2-11e9-9b05-58c3390c1403.png)
