### PR TITLE
Upgrade plug_canonical_host

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ElixirBoilerplate.Mixfile do
     [
       # HTTP server
       {:plug_cowboy, "~> 2.0"},
-      {:plug_canonical_host, "~> 0.3"},
+      {:plug_canonical_host, "~> 0.5"},
 
       # Phoenix
       {:phoenix, "~> 1.4.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ElixirBoilerplate.Mixfile do
     [
       # HTTP server
       {:plug_cowboy, "~> 2.0"},
-      {:plug_canonical_host, "~> 0.5"},
+      {:plug_canonical_host, "~> 0.6"},
 
       # Phoenix
       {:phoenix, "~> 1.4.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -31,7 +31,7 @@
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.1.6", "7280f4dd88d38ee07ca70a2974ca12b9bfdbb9fa8137e4692889cf097c1bb232", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", [hex: :phoenix, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.1", "6668d787e602981f24f17a5fbb69cc98f8ab085114ebfac6cc36e10a90c8e93c", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.7.2", "d7b7db7fbd755e8283b6c0a50be71ec0a3d67d9213d74422d9372effc8e87fd1", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
-  "plug_canonical_host": {:hex, :plug_canonical_host, "0.3.2", "517c2bcf20246ded776188565eb4a00bb1bb72e57fa9179af4a8e46f5ca5d695", [:mix], [{:plug, " ~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_canonical_host": {:hex, :plug_canonical_host, "0.5.0", "cb6d8ca1a6d764b6cbe753a0b6709132f166d707e9b8908b74d9f871fd33be4b", [:mix], [{:plug, " ~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_cowboy": {:hex, :plug_cowboy, "2.0.0", "ab0c92728f2ba43c544cce85f0f220d8d30fc0c90eaa1e6203683ab039655062", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -31,7 +31,7 @@
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.1.6", "7280f4dd88d38ee07ca70a2974ca12b9bfdbb9fa8137e4692889cf097c1bb232", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", [hex: :phoenix, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.1", "6668d787e602981f24f17a5fbb69cc98f8ab085114ebfac6cc36e10a90c8e93c", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.7.2", "d7b7db7fbd755e8283b6c0a50be71ec0a3d67d9213d74422d9372effc8e87fd1", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
-  "plug_canonical_host": {:hex, :plug_canonical_host, "0.5.0", "cb6d8ca1a6d764b6cbe753a0b6709132f166d707e9b8908b74d9f871fd33be4b", [:mix], [{:plug, " ~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_canonical_host": {:hex, :plug_canonical_host, "0.6.0", "c0c7c9d0f31e81b0d6a6e6a414070151d57425b196539f8e294dfc035312c9da", [:mix], [{:plug, " ~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_cowboy": {:hex, :plug_cowboy, "2.0.0", "ab0c92728f2ba43c544cce85f0f220d8d30fc0c90eaa1e6203683ab039655062", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},


### PR DESCRIPTION
The 0.5.0 release [fixes](https://github.com/remiprev/plug_canonical_host/pull/12) an annoying bug which adds a trailing `?` character when redirecting from a URI without a query string.

The 0.6.0 release [adds](https://github.com/remiprev/plug_canonical_host/pull/14) an `ignore` option to skip the behavior for specific requests.