### PR TITLE
Update credo_envvar to 0.1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule ElixirBoilerplate.Mixfile do
 
       # Linting
       {:credo, git: "https://github.com/mirego/credo", branch: "feature/add-consistency-filenames-check", only: [:dev, :test], override: true},
-      {:credo_envvar, git: "https://github.com/remiprev/credo_envvar", branch: "feature/feature/add-support-for-nested-module-with-siblings", only: ~w(dev test)a, runtime: false},
+      {:credo_envvar, "~> 0.1", only: ~w(dev test)a, runtime: false},
 
       # OTP Release
       {:distillery, "~> 2.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "cowboy": {:hex, :cowboy, "2.6.1", "f2e06f757c337b3b311f9437e6e072b678fcd71545a7b2865bdaa154d078593f", [:rebar3], [{:cowlib, "~> 2.7.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.7.0", "3ef16e77562f9855a2605900cedb15c1462d76fb1be6a32fc3ae91973ee543d2", [:rebar3], [], "hexpm"},
   "credo": {:git, "https://github.com/mirego/credo", "116d6bed281efef2f9cc631aedcee036dec85f71", [branch: "feature/add-consistency-filenames-check"]},
-  "credo_envvar": {:git, "https://github.com/remiprev/credo_envvar", "72b00b923593e12b158cdc4e73d8603e815d987e", [branch: "feature/feature/add-support-for-nested-module-with-siblings"]},
+  "credo_envvar": {:hex, :credo_envvar, "0.1.2", "82b4fb5d243db51439b8ff4e4ad4f18cd6cee54d3fcb1ef7b730b6bbc6b61605", [:mix], [{:credo, "~> 1.0.0", [hex: :credo, repo: "hexpm", optional: false]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "2.0.3", "b4e8aa43c100e16f122ccd6798cd51c48c79fd391c39d411f42b3cd765daccb0", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.6.0", "bfd84d90ff966e1f5d4370bdd3943432d8f65f07d3bab48001aebd7030590dcc", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Now that [this has been merged](https://github.com/kaorism/credo_envvar/pull/5), we don’t need my personal fork anymore 🎉 