### PR TITLE
Remove non-existent file from coveralls configuration

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -3,7 +3,8 @@
     "minimum_coverage": 30
   },
   "skip_files": [
-    "elixir_boilerplate/release/migration.ex",
+    "lib/elixir-boilerplate/release_tasks.ex",
+    "lib/mix/tasks/erlang.check_version.ex",
     "test/support"
   ]
 }


### PR DESCRIPTION
We noticed in a private project that this file isn’t present in the codebase. Therefore, there is no need to skip it when running coveralls.