### PR TITLE
Lint root .exs files with Credo

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -4,12 +4,12 @@
       name: "default",
       strict: true,
       files: %{
-        included: ["lib/", "test/", "priv/", "config/", "rel/"],
+        included: ["*.exs", "lib/", "test/", "priv/", "config/", "rel/"],
         excluded: []
       },
       checks: [
         {Credo.Check.Consistency.ExceptionNames},
-        {Credo.Check.Consistency.Filenames, excluded_paths: ["test/support", "priv/scripts", "rel", "priv/repo/migrations"]},
+        {Credo.Check.Consistency.Filenames, excluded_paths: ["test/support", "priv", "rel", "mix.exs"]},
         {Credo.Check.Consistency.LineEndings},
         {Credo.Check.Consistency.SpaceAroundOperators},
         {Credo.Check.Consistency.SpaceInParentheses},

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
-  inputs: ["mix.exs", ".credo.exs", ".formatter.exs", "{config,lib,priv,rel,test}/**/*.{ex,exs}"],
+  inputs: ["*.exs", "{config,lib,priv,rel,test}/**/*.{ex,exs}"],
   line_length: 180
 ]


### PR DESCRIPTION
We had some inconsistencies between `.credo.exs` and `.formatter.exs` regarding root-level Elixir scripts.

We now lint and format all root-level `.exs` files.