### PR TITLE
Do not freeze patch versions for Elixir, Erlang, Node.js and NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 before_script:
   - nvm install 10.14.2
   - nvm use 10.14.2
-  - npm install -g npm@6.4.1
+  - npm install -g npm@6.9.0
   - npm --prefix assets ci
   - mix compile
   - mix ecto.create

--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -22,11 +22,11 @@
 
 ## 🚧 Dependencies
 
-- Node.js (`10.14.2`)
-- NPM (`6.4.1`)
-- Elixir (`1.8.1`)
-- Erlang (`21.3.3`)
-- PostgreSQL (`~10.0`)
+- Node.js (`~> 10.14`)
+- NPM (`~> 6.9`)
+- Elixir (`~> 1.8`)
+- Erlang (`~> 21.3`)
+- PostgreSQL (`~> 10.0`)
 
 ## 🏎 Kickstart
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN mix deps.get --only ${MIX_ENV}
 COPY . .
 RUN mix compile --force
 
+RUN npm install -g npm@6.9.0
 RUN npm ci --prefix assets --no-audit --no-color --unsafe-perm
 RUN mix phx.digest
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ lint-stylelint:
 
 .PHONY: lint-prettier
 lint-prettier:
-	./assets/node_modules/.bin/prettier -l assets/.babelrc assets/webpack.config.js 'assets/{js,css}/**/*.{js,graphql,scss,css})' '**/*.md'
+	./assets/node_modules/.bin/prettier -l assets/.babelrc assets/webpack.config.js 'assets/{js,css,scripts}/**/*.{js,graphql,scss,css})' '**/*.md'
 
 .PHONY: test
 test: ## Run the test suite
@@ -104,7 +104,7 @@ format-elixir:
 
 .PHONY: format-prettier
 format-prettier:
-	./assets/node_modules/.bin/prettier --write 'assets/.babelrc' 'assets/webpack.config.js' 'assets/{js,css} /**/*.{js,graphql,scss,css})' '**/*.md'
+	./assets/node_modules/.bin/prettier --write 'assets/.babelrc' 'assets/webpack.config.js' 'assets/{js,css,scripts} /**/*.{js,graphql,scss,css})' '**/*.md'
 
 # Development targets
 # -------------------

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -211,6 +211,12 @@
             "path-parse": "^1.0.5"
           }
         },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2756,6 +2762,12 @@
           "version": "1.3.88",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.88.tgz",
           "integrity": "sha512-UPV4NuQMKeUh1S0OWRvwg0PI8ASHN9kBC8yDTk1ROXLC85W5GnhTRu/MZu3Teqx3JjlQYuckuHYXSUSgtb3J+A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
       }
@@ -5927,6 +5939,12 @@
           "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
           "dev": true
         },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -6647,7 +6665,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6668,12 +6687,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6688,17 +6709,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6815,7 +6839,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6827,6 +6852,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6841,6 +6867,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6848,12 +6875,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6872,6 +6901,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6952,7 +6982,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6964,6 +6995,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7049,7 +7081,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7085,6 +7118,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7104,6 +7138,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7147,12 +7182,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9287,6 +9324,14 @@
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "nomnom": {
@@ -9334,6 +9379,14 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -11450,9 +11503,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
       "dev": true
     },
     "serialize-javascript": {
@@ -14058,6 +14111,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         },
         "expand-tilde": {
@@ -14400,6 +14461,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         },
         "debug": {
@@ -14620,6 +14689,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         },
         "debug": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,14 +1,14 @@
 {
+  "name": "",
   "private": true,
   "engines": {
-    "node": "10.14.2",
-    "npm": "6.4.1"
+    "node": "~> 10.14",
+    "npm": "~> 6.9"
   },
   "scripts": {
-    "deploy": "npm run enforce-engine-versions && ./node_modules/.bin/webpack --mode production",
-    "watch": "npm run enforce-engine-versions && ./node_modules/.bin/webpack --mode development --watch-stdin",
-    "enforce-engine-versions": "./scripts/enforce-engine-versions.js",
-    "preinstall": "npm run enforce-engine-versions"
+    "deploy": "npm run enforce-engine-versions && npx webpack --mode production",
+    "watch": "npm run enforce-engine-versions && npx webpack --mode development --watch-stdin",
+    "enforce-engine-versions": "./scripts/enforce-engine-versions.js"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -22,6 +22,7 @@
     "mini-css-extract-plugin": "^0.4.0",
     "optimize-css-assets-webpack-plugin": "^4.0.0",
     "prettier": "1.16.4",
+    "semver": "6.0.0",
     "stylelint": "9.2.1",
     "stylelint-config-mirego": "1.0.1",
     "stylelint-order": "0.8.1",

--- a/assets/scripts/enforce-engine-versions.js
+++ b/assets/scripts/enforce-engine-versions.js
@@ -4,22 +4,43 @@
 /* eslint-disable no-console */
 
 let exitStatus = 0;
+let semver;
 
-const {node: expectedNodeVersion, npm: expectedNpmVersion} = require('../package.json').engines;
+try {
+  semver = require('semver');
+} catch {
+  // The `semver` might not be available since we run this
+  // script as a `preinstall` hook.
+  console.info('Skipping “enforce-engine-versions” script because `semver` module is not available.');
+  process.exit(exitStatus);
+}
+
+const {
+  node: expectedNodeVersion,
+  npm: expectedNpmVersion
+} = require('../package.json').engines;
 const actualNodeVersion = process.versions.node;
-const actualNpmVersion = require('child_process').execSync('npm -v').toString().replace(/\n/, '');
+
+const actualNpmVersion = require('child_process')
+  .execSync('npm -v')
+  .toString()
+  .replace(/\n/, '');
 
 console.info(`Node.js ${actualNodeVersion}`);
 console.info(`NPM ${actualNpmVersion}`);
 console.info('');
 
-if (expectedNodeVersion !== actualNodeVersion) {
-  console.error(`You are using Node.js ${actualNodeVersion} but the required version specified in package.json is ${expectedNodeVersion}`);
+if (!semver.satisfies(actualNodeVersion, expectedNodeVersion)) {
+  console.error(
+    `You are using Node.js ${actualNodeVersion} but the required version specified in package.json is ${expectedNodeVersion}`
+  );
   exitStatus = 1;
 }
 
-if (expectedNpmVersion !== actualNpmVersion) {
-  console.error(`You are using NPM ${actualNpmVersion} but the required version specified in package.json is ${expectedNpmVersion}`);
+if (!semver.satisfies(actualNpmVersion, expectedNpmVersion)) {
+  console.error(
+    `You are using NPM ${actualNpmVersion} but the required version specified in package.json is ${expectedNpmVersion}`
+  );
   exitStatus = 1;
 }
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule ElixirBoilerplate.Mixfile do
     [
       app: :elixir_boilerplate,
       version: "0.0.1",
-      elixir: "1.8.1",
-      erlang: "21.3.3",
+      elixir: "~> 1.8",
+      erlang: "~> 21.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_paths: ["test"],
       test_pattern: "**/*_test.exs",


### PR DESCRIPTION
Instead of freezing whole version numbers for Erlang, Elixir, Node.js and NPM, we now only freeze major and minor numbers. So now the version requirements are truly:

- Node.js (`~> 10.14`)
- NPM (`~> 6.9`)
- Elixir (`~> 1.8`)
- Erlang (`~> 21.3`)

:tada:

Closes #13 