### PR TITLE
Fix format-prettier task in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ lint-stylelint:
 
 .PHONY: lint-prettier
 lint-prettier:
-	./assets/node_modules/.bin/prettier -l assets/.babelrc assets/webpack.config.js 'assets/{js,css,scripts}/**/*.{js,graphql,scss,css})' '**/*.md'
+	./assets/node_modules/.bin/prettier -l assets/.babelrc assets/webpack.config.js 'assets/{js,css,scripts}/**/*.{js,graphql,scss,css}' '**/*.md'
 
 .PHONY: test
 test: ## Run the test suite
@@ -104,7 +104,7 @@ format-elixir:
 
 .PHONY: format-prettier
 format-prettier:
-	./assets/node_modules/.bin/prettier --write 'assets/.babelrc' 'assets/webpack.config.js' 'assets/{js,css,scripts} /**/*.{js,graphql,scss,css})' '**/*.md'
+	./assets/node_modules/.bin/prettier --write 'assets/.babelrc' 'assets/webpack.config.js' 'assets/{js,css,scripts}/**/*.{js,graphql,scss,css}' '**/*.md'
 
 # Development targets
 # -------------------

--- a/assets/scripts/enforce-engine-versions.js
+++ b/assets/scripts/enforce-engine-versions.js
@@ -11,7 +11,9 @@ try {
 } catch {
   // The `semver` might not be available since we run this
   // script as a `preinstall` hook.
-  console.info('Skipping “enforce-engine-versions” script because `semver` module is not available.');
+  console.info(
+    'Skipping “enforce-engine-versions” script because `semver` module is not available.'
+  );
   process.exit(exitStatus);
 }
 


### PR DESCRIPTION
Running `mix format-prettier` wasn’t actually formatting the JavaScript files in `assets/`. A sneaky parenthesis made its way into the command.