### PR TITLE
Downgrade NPM version requirement to 6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ before_install:
 before_script:
   - nvm install 10.14.2
   - nvm use 10.14.2
-  - npm install -g npm@6.9.0
   - npm --prefix assets ci
   - mix compile
   - mix ecto.create

--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -23,7 +23,7 @@
 ## 🚧 Dependencies
 
 - Node.js (`~> 10.14`)
-- NPM (`~> 6.9`)
+- NPM (`~> 6.4`)
 - Elixir (`~> 1.8`)
 - Erlang (`~> 21.3`)
 - PostgreSQL (`~> 10.0`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN mix deps.get --only ${MIX_ENV}
 COPY . .
 RUN mix compile --force
 
-RUN npm install -g npm@6.9.0
 RUN npm ci --prefix assets --no-audit --no-color --unsafe-perm
 RUN mix phx.digest
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,14 +1,18 @@
 {
-  "name": "",
+  "name": "elixir-boilerplate",
+  "version": "0.0.1",
   "private": true,
+  "engine-strict": true,
   "engines": {
-    "node": "~> 10.14",
-    "npm": "~> 6.9"
+    "node": "~10.14",
+    "npm": "~6.4"
   },
   "scripts": {
     "deploy": "npm run enforce-engine-versions && npx webpack --mode production",
     "watch": "npm run enforce-engine-versions && npx webpack --mode development --watch-stdin",
-    "enforce-engine-versions": "./scripts/enforce-engine-versions.js"
+    "enforce-engine-versions": "./scripts/enforce-engine-versions.js",
+    "preinstall": "npm run enforce-engine-versions",
+    "postinstall": "npm run enforce-engine-versions"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Like @gcauchon suggested in https://github.com/mirego/elixir-boilerplate/pull/15, we enforced npm 6.9.0 for no valid reason. Let’s use the same NPM version as the one provided by Node 10.14.