### PR TITLE
Do not freeze Elixir patch version in Travis and Docker files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Elixir baby!
 language: 'elixir'
 
-elixir: 1.8.1
+elixir: 1.8
 otp_release: 21.3.3
 
 # Make sure PostgreSQL is running

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Step 1 - build the OTP binary
 #
-FROM elixir:1.8.1-alpine AS builder
+FROM elixir:1.8-alpine AS builder
 
 ARG APP_NAME
 ARG APP_VERSION


### PR DESCRIPTION
We’re requiring `elixir ~> 1.8` now, so we don’t need to hardcode `1.8.1` in the Travis build configuration and Dockerfile.