### PR TITLE
Do not make APP_NAME and APP_VERSION customizable in “make” commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Configuration
 # -------------
 
-APP_NAME ?= `grep 'app:' mix.exs | sed -e 's/\[//g' -e 's/ //g' -e 's/app://' -e 's/[:,]//g'`
-APP_VERSION ?= `grep 'version:' mix.exs | cut -d '"' -f2`
+APP_NAME = `grep 'app:' mix.exs | sed -e 's/\[//g' -e 's/ //g' -e 's/app://' -e 's/[:,]//g'`
+APP_VERSION = `grep 'version:' mix.exs | cut -d '"' -f2`
 DOCKER_IMAGE_TAG ?= latest
 GIT_REVISION ?= `git rev-parse HEAD`
 


### PR DESCRIPTION
1. We don’t need to customize these variables when running `make` commands
2. It wasn’t actually working correctly — the variable were only used in _some_ places when building the OTP release

The app name and version used when making a build should always be the ones stored in `mix.exs`.