### PR TITLE
Install Node.js without strict patch version in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /build
 # This step installs all the build tools we'll need
 RUN apk update && \
     apk upgrade --no-cache && \
-    apk add --no-cache nodejs=10.14.2-r0 npm=10.14.2-r0 git build-base
+    apk add --no-cache nodejs~=10.14 npm~=10.14 git build-base
 RUN mix local.rebar --force && \
     mix local.hex --force
 


### PR DESCRIPTION
Since [we now require](https://github.com/mirego/elixir-boilerplate/blob/a80c3e575bc7243df86584ab2353d05bdb3e5d51/assets/package.json#L6-L9) `~10.14` and `~6.4` versions for Node.js and NPM, we don’t need to install specific versions (with patch number) in the Docker build.