### PR TITLE
Use right configuration option to set repo pool size

### DIFF
--- a/rel/config/config.exs
+++ b/rel/config/config.exs
@@ -73,7 +73,7 @@ config :phoenix, :json_library, Jason
 
 # Configure Repo with Postgres
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
-  size: Utils.Environment.get("DATABASE_POOL_SIZE"),
+  pool_size: Utils.Environment.get_integer("DATABASE_POOL_SIZE"),
   ssl: Utils.Environment.get_boolean("DATABASE_SSL"),
   url: Utils.Environment.get("DATABASE_URL")
 


### PR DESCRIPTION
The option is actually named `pool_size` ([reference](https://hexdocs.pm/ecto/Ecto.Repo.html)), not `size`.