### PR TITLE
Expose application version in config

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,8 +7,7 @@ use Mix.Config
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   root: ".",
-  server: true,
-  version: Application.spec(:elixir_boilerplate, :vsn)
+  server: true
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/lib/elixir_boilerplate_web/health/plug.ex
+++ b/lib/elixir_boilerplate_web/health/plug.ex
@@ -2,10 +2,7 @@ defmodule ElixirBoilerplateWeb.Health.Plug do
   use Plug.Builder
 
   def call(%{request_path: "/health"} = conn, _) do
-    version =
-      :elixir_boilerplate
-      |> Application.spec(:vsn)
-      |> String.Chars.to_string()
+    version = Application.get_env(:elixir_boilerplate, :version)
 
     conn
     |> put_resp_header("content-type", "application/json")

--- a/rel/config/config.exs
+++ b/rel/config/config.exs
@@ -51,7 +51,7 @@ defmodule Utils do
       |> Application.spec(:vsn)
       |> case do
         nil -> Mix.Project.config()[:version]
-        version -> List.to_string(version)
+        version -> to_string(version)
       end
     end
   end
@@ -64,6 +64,7 @@ port = Utils.Environment.get("PORT")
 
 # General application configuration
 config :elixir_boilerplate,
+  version: Utils.Version.get(),
   canonical_host: host,
   force_ssl: force_ssl,
   ecto_repos: [ElixirBoilerplate.Repo]

--- a/test/elixir_boilerplate_web/health/plug_test.exs
+++ b/test/elixir_boilerplate_web/health/plug_test.exs
@@ -4,10 +4,8 @@ defmodule ElixirBoilerplateWeb.Health.PlugTest do
   test "GET /health", %{conn: conn} do
     conn = get(conn, "/health")
 
-    version =
-      :elixir_boilerplate
-      |> Application.spec(:vsn)
-      |> String.Chars.to_string()
+    # credo:disable-for-next-line CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime
+    version = Application.get_env(:elixir_boilerplate, :version)
 
     assert json_response(conn, 200) == %{
              "status" => "ok",


### PR DESCRIPTION
We now have a way to expose the current application version (either fetched from `Mixfile` or from the OTP release).