### PR TITLE
Use official Credo release

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -9,7 +9,6 @@
       },
       checks: [
         {Credo.Check.Consistency.ExceptionNames},
-        {Credo.Check.Consistency.Filenames, excluded_paths: ["test/support", "priv", "rel", "mix.exs"]},
         {Credo.Check.Consistency.LineEndings},
         {Credo.Check.Consistency.SpaceAroundOperators},
         {Credo.Check.Consistency.SpaceInParentheses},

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule ElixirBoilerplate.Mixfile do
       {:sentry, "~> 7.0"},
 
       # Linting
-      {:credo, git: "https://github.com/mirego/credo", branch: "feature/add-consistency-filenames-check", only: [:dev, :test], override: true},
+      {:credo, "~> 1.0", only: [:dev, :test], override: true},
       {:credo_envvar, "~> 0.1", only: ~w(dev test)a, runtime: false},
 
       # OTP Release

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.6.3", "99aa50e94e685557cad82e704457336a453d4abcb77839ad22dbe71f311fcc06", [:rebar3], [{:cowlib, "~> 2.7.3", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
-  "credo": {:git, "https://github.com/mirego/credo", "116d6bed281efef2f9cc631aedcee036dec85f71", [branch: "feature/add-consistency-filenames-check"]},
+  "credo": {:hex, :credo, "1.0.4", "d2214d4cc88c07f54004ffd5a2a27408208841be5eca9f5a72ce9e8e835f7ede", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "credo_envvar": {:hex, :credo_envvar, "0.1.2", "82b4fb5d243db51439b8ff4e4ad4f18cd6cee54d3fcb1ef7b730b6bbc6b61605", [:mix], [{:credo, "~> 1.0.0", [hex: :credo, repo: "hexpm", optional: false]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "2.0.3", "b4e8aa43c100e16f122ccd6798cd51c48c79fd391c39d411f42b3cd765daccb0", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [:mix], [], "hexpm"},


### PR DESCRIPTION
https://github.com/rrrene/credo/pull/623 will probably never get merged, so let’s keep using an official Credo release.

I’ll probably extract the `Credo.Check.Consistency.Filenames` check into a separate package.