### PR TITLE
Add CredoFilenameConsistency check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -53,7 +53,8 @@
         {Credo.Check.Warning.UnusedStringOperation},
         {Credo.Check.Warning.UnusedTupleOperation},
         {Credo.Check.Warning.OperationWithConstantResult},
-        {CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime}
+        {CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime},
+        {CredoFilenameConsistency.Check.Consistency.FilenameConsistency, excluded_paths: ["test/support", "priv", "rel", "mix.exs"]}
       ]
     }
   ]

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,8 @@ defmodule ElixirBoilerplate.Mixfile do
 
       # Linting
       {:credo, "~> 1.0", only: [:dev, :test], override: true},
-      {:credo_envvar, "~> 0.1", only: ~w(dev test)a, runtime: false},
+      {:credo_envvar, "~> 0.1", only: [:dev, :test], runtime: false},
+      {:credo_filename_consistency, "~> 0.1", only: [:dev, :test], runtime: false},
 
       # OTP Release
       {:distillery, "~> 2.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
   "credo": {:hex, :credo, "1.0.4", "d2214d4cc88c07f54004ffd5a2a27408208841be5eca9f5a72ce9e8e835f7ede", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "credo_envvar": {:hex, :credo_envvar, "0.1.2", "82b4fb5d243db51439b8ff4e4ad4f18cd6cee54d3fcb1ef7b730b6bbc6b61605", [:mix], [{:credo, "~> 1.0.0", [hex: :credo, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo_filename_consistency": {:hex, :credo_filename_consistency, "0.1.0", "956a1176069cd10a905c73415efaf9a90747b67bd583bf46580ce1184066606d", [:make, :mix], [{:credo, "~> 1.0", [hex: :credo, repo: "hexpm", optional: false]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "2.0.3", "b4e8aa43c100e16f122ccd6798cd51c48c79fd391c39d411f42b3cd765daccb0", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Aaaaaand we’re back (#31) with filename consistency, now that [CredoFilenameConsistency](https://github.com/mirego/credo_filename_consistency) is released!