### PR TITLE
Add Corsica default configuration

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -18,6 +18,7 @@ PORT=4000
 SECRET_KEY_BASE= # Generate secret with `mix phx.gen.secret`
 SESSION_KEY=elixir_boilerplate
 SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
+CORS_ALLOWED_ORIGINS=*
 
 # Database configuration
 # Use `postgres://username:password@localhost/elixir_boilerplate_dev` if you have username/password credentials

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This boilerplate comes with batteries included, you’ll find:
 - Database integration using [Ecto](https://hexdocs.pm/ecto/Ecto.html)
 - Translations with [Gettext](https://hexdocs.pm/gettext/Gettext.html)
 - [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html) tests and code coverage using [ExCoveralls](https://hexdocs.pm/excoveralls/api-reference.html)
+- CORS management with [Corsica](https://github.com/whatyouhide/corsica)
 - Opinionated linting with [Credo](http://credo-ci.org)
 - Static code analysis with _Dialyzer_/[Dialyxir](https://hexdocs.pm/dialyxir/readme.html)
 - OTP release using [Distillery](https://hexdocs.pm/distillery/home.html) and [Docker](https://www.docker.com)

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -22,6 +22,13 @@ defmodule Environment do
     end
   end
 
+  def get_list(key) do
+    case get(key) do
+      value when is_bitstring(value) -> String.split(value, ",")
+      _ -> []
+    end
+  end
+
   def exists?(key) do
     case get(key) do
       "" -> false
@@ -69,6 +76,11 @@ if Environment.exists?("BASIC_AUTH_USERNAME") do
       password: Environment.get("BASIC_AUTH_PASSWORD")
     ]
 end
+
+# Configure CORS
+config :elixir_boilerplate, :corsica,
+  origins: Environment.get_list("CORS_ALLOWED_ORIGINS"),
+  allow_headers: :all
 
 # Configure Sentry
 config :sentry,

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -9,9 +9,9 @@ defmodule ElixirBoilerplateWeb.Endpoint do
   )
 
   plug(ElixirBoilerplateWeb.Health.Plug)
-  plug(:cors)
   plug(:canonical_host)
   plug(:force_ssl)
+  plug(:cors)
   plug(:basic_auth)
   plug(:session)
 

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -9,6 +9,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
   )
 
   plug(ElixirBoilerplateWeb.Health.Plug)
+  plug(:cors)
   plug(:canonical_host)
   plug(:force_ssl)
   plug(:basic_auth)
@@ -86,6 +87,18 @@ defmodule ElixirBoilerplateWeb.Endpoint do
       opts = BasicAuth.init(use_config: {:elixir_boilerplate, :basic_auth})
 
       BasicAuth.call(conn, opts)
+    else
+      conn
+    end
+  end
+
+  defp cors(conn, _opts) do
+    corsica_config = Application.get_env(:elixir_boilerplate, :corsica)
+
+    if corsica_config do
+      opts = Corsica.init(corsica_config)
+
+      Corsica.call(conn, opts)
     else
       conn
     end

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule ElixirBoilerplate.Mixfile do
       # HTTP server
       {:plug_cowboy, "~> 2.0"},
       {:plug_canonical_host, "~> 0.6"},
+      {:corsica, "~> 1.0"},
 
       # Phoenix
       {:phoenix, "~> 1.4.0"},


### PR DESCRIPTION
Since we mostly create API for SPA, we add the default configuration needed for CORS with Corsica.

Closes #10 