### PR TITLE
Improve “make” target naming

### DIFF
--- a/priv/scripts/ci-check.sh
+++ b/priv/scripts/ci-check.sh
@@ -27,17 +27,20 @@ run() {
   fi
 }
 
-header "Code format and linting…"
+header "Lint files…"
 run make lint
+
+header "Check code format…"
+run make check-format
 
 header "Run tests…"
 run make test
 
-header "Code coverage…"
-run make test-coverage
+header "Check test code coverage…"
+run make check-code-coverage
 
-header "Dialyzer…"
-run make dialyze
+header "Typecheck files…"
+run make check-typespecs
 
 header "Run seed data…"
 run mix run priv/repo/seeds.exs
@@ -45,7 +48,7 @@ run mix run priv/repo/seeds.exs
 header "Run dummy data…"
 run mix run priv/repo/dummy.exs
 
-header "Build Docker image running an OTP release…"
+header "Build Docker image…"
 run make build
 
 if [ ${error_status} -ne 0 ]; then


### PR DESCRIPTION
### Naming convention

* We now use `lint-<stuff>` for targets that lint stuff
* We now use `format-<stuff>` for targets that format or _fix_ stuff
* We now use `check-<stuff>` for targets that check stuff (eg. types, formatting, code coverage, etc.)

### Renaming

* `lint-<tool>` and `format-<tool>` have been converted to `lint-<type>` and `format-<type>` (where `type` is `styles`, `scripts`, etc.)
* `dev-start` and `dev-stop` have been converted to the more accurate `services-start` and `services-stop` because they manage Docker Compose services

### Bonus!

* We now store file patterns as variables at the top of the `Makefile` to make them more visible and prevent them from being hardcoded or duplicated deep down in the file
* Targets are now grouped:
  * Build targets
  * Development targets
  * Check, lint and format targets
  * Service container targets