### PR TITLE
Relax Node.js and NPM version requirements

### DIFF
--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -22,8 +22,8 @@
 
 ## 🚧 Dependencies
 
-- Node.js (`~> 10.14`)
-- NPM (`~> 6.4`)
+- Node.js (`>= 10.14, < 11.0`)
+- NPM (`>= 6.4, < 7.0`)
 - Elixir (`~> 1.8`)
 - Erlang (`~> 21.3`)
 - PostgreSQL (`~> 10.0`)

--- a/assets/package.json
+++ b/assets/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "engine-strict": true,
   "engines": {
-    "node": "~10.14",
-    "npm": "~6.4"
+    "node": "^10.14",
+    "npm": "^6.4"
   },
   "scripts": {
     "deploy": "npm run enforce-engine-versions && npx webpack --mode production",


### PR DESCRIPTION
We now enforce less strict engine version requirements for Node.js and NPM.

I don’t think it’s a high-risk change since there should never be any breaking changes between minor Node.js and NPM releases.

Maybe this is the first step in moving _all_ version requirements to major versions (eg. Elixir `1.*` and Erlang `21.*`)  🤷‍♂ 

I would love to hear @charlesdemers and @simonprev take on this 👋 

Closes #13 