### PR TITLE
Add user-password placeholders in the DATABASE_URL

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -20,7 +20,7 @@ SESSION_KEY=elixir_boilerplate
 SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
 
 # Database configuration
-DATABASE_URL=postgres://localhost/elixir_boilerplate_dev
+DATABASE_URL=postgres://username:password@localhost/elixir_boilerplate_dev
 DATABASE_POOL_SIZE=20
 
 # Basic Authentication


### PR DESCRIPTION
This helps prevent `KeyError exception: key :password not found.` Without the username/password we get the following error when the server is started :

```
[error] GenServer #PID<0.558.0> terminating
** (RuntimeError) connect raised KeyError exception: key :password not found.The exception details are hidden, as they may contain sensitive data such as database credentials. You may set :show_sensitive_data_on_connection_error to true if you wish to see all of the details
    (elixir) lib/keyword.ex:389: Keyword.fetch!/2
    (postgrex) lib/postgrex/protocol.ex:719: Postgrex.Protocol.auth_md5/4
    (postgrex) lib/postgrex/protocol.ex:576: Postgrex.Protocol.handshake/2
    (db_connection) lib/db_connection/connection.ex:66: DBConnection.Connection.connect/2
    (connection) lib/connection.ex:622: Connection.enter_connect/5
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: nil
State: Postgrex.Protocol
```