### PR TITLE
Remove Docker Compose make targets

### DIFF
--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -50,7 +50,7 @@ A `Makefile` is present at the root and expose common tasks. The list of these c
 
 ### Database
 
-To avoid running PostgreSQL locally on your machine, a `docker-compose.yml` file is included to be able start a PostgreSQL server in a Docker container with `make services-start`.
+To avoid running PostgreSQL locally on your machine, a `docker-compose.yml` file is included to be able start a PostgreSQL server in a Docker container with `docker-compose up postgresql`.
 
 ### Tests
 
@@ -93,4 +93,4 @@ Each deployment is made from a Git tag. The codebase version is managed with [`i
 
 ### Container
 
-A Docker image running an _OTP release_ can be created with `make build`, tested with `make services-start` and pushed to a registry with `make push`.
+A Docker image running an _OTP release_ can be created with `make build`, tested with `docker-compose up application` and pushed to a registry with `make push`.

--- a/Makefile
+++ b/Makefile
@@ -105,14 +105,3 @@ lint-scripts:
 .PHONY: lint-styles
 lint-styles:
 	./assets/node_modules/.bin/stylelint --syntax scss --config assets/.stylelintrc $(STYLES_PATTERN)
-
-# Service container targets
-# -------------------------
-
-.PHONY: services-start
-services-start: build ## Start every service in the Docker Compose environment
-	docker-compose up
-
-.PHONY: services-stop
-services-stop: ## Stop every service in the Docker Compose environment
-	docker-compose down


### PR DESCRIPTION
We were only making two references to the `services-start` target in the README.md. 

Now we explictely tell developers to use `docker-compose up <service>` if they want to use it 😄 