### PR TITLE
Add more examples for DATABASE_URL variable in .env.dev

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -20,7 +20,9 @@ SESSION_KEY=elixir_boilerplate
 SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
 
 # Database configuration
-# Use `postgres://username:password@localhost/elixir_boilerplate_dev` if you have username/password credentials
+# - Use `postgres://localhost/elixir_boilerplate_dev` if you have a local PostgreSQL server
+# - Use `postgres://username:password@localhost/elixir_boilerplate_dev` if you have a local PostgreSQL server with credentials
+# - Use `postgres://postgres:development@localhost/elixir_boilerplate_dev` if you’re using the PostgreSQL server provided by Docker Compose
 DATABASE_URL=postgres://localhost/elixir_boilerplate_dev
 DATABASE_POOL_SIZE=20
 


### PR DESCRIPTION
Let’s be explicit about what kinds of value developers can use for the `DATABASE_URL` environment variable.