### PR TITLE
Remove redundant comments from configuration files

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,27 +1,21 @@
 use Mix.Config
 
-# Extract version from Mix
 version = Mix.Project.config()[:version]
 
-# Configure application
 config :elixir_boilerplate,
   ecto_repos: [ElixirBoilerplate.Repo],
   version: version
 
-# Configure Phoenix
 config :phoenix, :json_library, Jason
 
-# Configure Phoenix endpoint
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   pubsub: [name: ElixirBoilerplate.PubSub, adapter: Phoenix.PubSub.PG2],
   render_errors: [view: ElixirBoilerplateWeb.Errors.View, accepts: ~w(html json)]
 
-# Configure Gettext
 config :elixir_boilerplate, ElixirBoilerplate.Gettext, default_locale: "en"
 
 config :elixir_boilerplate, :corsica, allow_headers: :all
 
-# Configure Sentry
 config :sentry,
   included_environments: [:prod],
   root_source_code_path: File.cwd!(),

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,8 +1,5 @@
 use Mix.Config
 
-# The watchers configuration can be used to run external
-# watchers to your application. For example, we use it
-# with brunch.io to recompile .js and .css sources.
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   code_reloader: true,
   check_origin: false,
@@ -12,10 +9,7 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
       "watch",
       cd: Path.expand("../assets", __DIR__)
     ]
-  ]
-
-# Watch static and templates for browser reloading.
-config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
+  ],
   live_reload: [
     patterns: [
       ~r{priv/gettext/.*$},
@@ -25,9 +19,6 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
     ]
   ]
 
-# Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 
-# Set a higher stacktrace during development. Avoid configuring such
-# in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,11 +1,9 @@
 use Mix.Config
 
-# Configure Phoenix endpoint
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true
 
-# Configure Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   level: :info,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -43,18 +43,15 @@ scheme = if force_ssl, do: "https", else: "http"
 host = Environment.get("CANONICAL_HOST")
 port = Environment.get("PORT")
 
-# Configure application
 config :elixir_boilerplate,
   canonical_host: host,
   force_ssl: force_ssl
 
-# Configure Ecto repo
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
   pool_size: Environment.get_integer("DATABASE_POOL_SIZE"),
   ssl: Environment.get_boolean("DATABASE_SSL"),
   url: Environment.get("DATABASE_URL")
 
-# Configure Phoenix endpoint
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),
   http: [port: port],
@@ -68,7 +65,6 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   ],
   url: [scheme: scheme, host: host, port: port]
 
-# Configure Basic Auth
 if Environment.exists?("BASIC_AUTH_USERNAME") do
   config :elixir_boilerplate,
     basic_auth: [
@@ -79,7 +75,6 @@ end
 
 config :elixir_boilerplate, :corsica, origins: Environment.get_list("CORS_ALLOWED_ORIGINS")
 
-# Configure Sentry
 config :sentry,
   dsn: Environment.get("SENTRY_DSN"),
   environment_name: Environment.get("SENTRY_ENVIRONMENT_NAME")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,5 @@
 use Mix.Config
 
-# Configure the endpoint for tests
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   http: [port: 4001],
   server: false,
@@ -18,8 +17,6 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
     port: "443"
   ]
 
-# Print only warnings and errors during test
 config :logger, level: :warn
 
-# Configure Repo with a sandboxed Postgres
 config :elixir_boilerplate, ElixirBoilerplate.Repo, pool: Ecto.Adapters.SQL.Sandbox


### PR DESCRIPTION
We had a lot of redundant “grouping” comments in configuration files, that were only describing the application or the module in the configuration block below, eg.

```elixir
# Configure Phoenix endpoint
config :habs, HabsWeb.Endpoint,
  foo: "bar",
  baz: true

# Configure Sentry
config :sentry,
  foo: "bar",
  baz: true
```

I don’t think we need those 😄