### PR TITLE
Fix live_reload by using a more permissive regex

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,8 +14,7 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
     patterns: [
       ~r{priv/gettext/.*$},
       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
-      ~r{lib/elixir_boilerplate_web/views/.*(ex)$},
-      ~r{lib/elixir_boilerplate_web/templates/.*(eex)$}
+      ~r{lib/elixir_boilerplate_web/.*(ee?x)$}
     ]
   ]
 


### PR DESCRIPTION
The new regex works on our module system for elixir and EEX files.