### PR TITLE
Set max size to 40 lines for ABCSize credo check rule

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -30,7 +30,7 @@
         {Credo.Check.Readability.TrailingBlankLine},
         {Credo.Check.Readability.TrailingWhiteSpace},
         {Credo.Check.Readability.VariableNames},
-        {Credo.Check.Refactor.ABCSize},
+        {Credo.Check.Refactor.ABCSize, max_size: 40},
         {Credo.Check.Refactor.CaseTrivialMatches},
         {Credo.Check.Refactor.CondStatements},
         {Credo.Check.Refactor.FunctionArity},


### PR DESCRIPTION
By default, max_size for `Credo.Check.Refactor.ABCSize` is **30 lines**.
As it's a bit restrictive, we propose to increase it to **40 lines**