### PR TITLE
Fix Corsica configuration to support "*" as an environment variable

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -12,13 +12,13 @@
 
 # Server configuration
 CANONICAL_HOST=localhost
+CORS_ALLOWED_ORIGINS=*
 DEBUG_ERRORS=true
 FORCE_SSL=false
 PORT=4000
 SECRET_KEY_BASE= # Generate secret with `mix phx.gen.secret`
 SESSION_KEY=elixir_boilerplate
 SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
-CORS_ALLOWED_ORIGINS=*
 
 # Database configuration
 # - Use `postgres://localhost/elixir_boilerplate_dev` if you have a local PostgreSQL server

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,9 +12,9 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   pubsub: [name: ElixirBoilerplate.PubSub, adapter: Phoenix.PubSub.PG2],
   render_errors: [view: ElixirBoilerplateWeb.Errors.View, accepts: ~w(html json)]
 
-config :elixir_boilerplate, ElixirBoilerplate.Gettext, default_locale: "en"
+config :elixir_boilerplate, Corsica, allow_headers: :all
 
-config :elixir_boilerplate, :corsica, allow_headers: :all
+config :elixir_boilerplate, ElixirBoilerplate.Gettext, default_locale: "en"
 
 config :sentry,
   included_environments: ~w(prod)a,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -22,10 +22,13 @@ defmodule Environment do
     end
   end
 
-  def get_list(key) do
-    case get(key) do
-      value when is_bitstring(value) -> String.split(value, ",")
-      _ -> []
+  def get_list_or_first_value(key) do
+    with value when is_bitstring(value) <- get(key),
+         [single_value] <- String.split(value, ",") do
+      single_value
+    else
+      values when is_list(values) -> values
+      _ -> nil
     end
   end
 
@@ -65,6 +68,8 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   ],
   url: [scheme: scheme, host: host, port: port]
 
+config :elixir_boilerplate, Corsica, origins: Environment.get_list_or_first_value("CORS_ALLOWED_ORIGINS")
+
 if Environment.exists?("BASIC_AUTH_USERNAME") do
   config :elixir_boilerplate,
     basic_auth: [
@@ -72,8 +77,6 @@ if Environment.exists?("BASIC_AUTH_USERNAME") do
       password: Environment.get("BASIC_AUTH_PASSWORD")
     ]
 end
-
-config :elixir_boilerplate, :corsica, origins: Environment.get_list("CORS_ALLOWED_ORIGINS")
 
 config :sentry,
   dsn: Environment.get("SENTRY_DSN"),

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -80,6 +80,12 @@ defmodule ElixirBoilerplateWeb.Endpoint do
     end
   end
 
+  defp cors(conn, _opts) do
+    opts = Corsica.init(Application.get_env(:elixir_boilerplate, Corsica))
+
+    Corsica.call(conn, opts)
+  end
+
   defp basic_auth(conn, _opts) do
     basic_auth_config = Application.get_env(:elixir_boilerplate, :basic_auth)
 
@@ -87,18 +93,6 @@ defmodule ElixirBoilerplateWeb.Endpoint do
       opts = BasicAuth.init(use_config: {:elixir_boilerplate, :basic_auth})
 
       BasicAuth.call(conn, opts)
-    else
-      conn
-    end
-  end
-
-  defp cors(conn, _opts) do
-    corsica_config = Application.get_env(:elixir_boilerplate, :corsica)
-
-    if corsica_config do
-      opts = Corsica.init(corsica_config)
-
-      Corsica.call(conn, opts)
     else
       conn
     end

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "corsica": {:hex, :corsica, "1.1.2", "5ad8b9dcbeeda4762d78a57c0c8c2f88e1eef8741508517c98cb79e0db1f107d", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.6.3", "99aa50e94e685557cad82e704457336a453d4abcb77839ad22dbe71f311fcc06", [:rebar3], [{:cowlib, "~> 2.7.3", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
   "credo": {:hex, :credo, "1.0.4", "d2214d4cc88c07f54004ffd5a2a27408208841be5eca9f5a72ce9e8e835f7ede", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
👀 Follow up to #36

Following the [Corsica](https://hexdocs.pm/corsica/Corsica) documentation, the `origins` option handle the "allow all" in a specific way to whitelist request from any website domain.

> The value `"*"` can also be used to match every origin and reply with `*` as the value of the `access-control-allow-origin` header. If `"*"` is used, it must be used as the only value of `:origins` (**that is, it can’t be used inside a list of accepted origins**).

With `CORS_ALLOWED_ORIGINS=*` set, here is the difference :

## Before

```shell
> curl --request OPTIONS --header "Origin: http://foo.bar" --header "Access-Control-Request-Method: POST" --verbose http://localhost:4000
…
> OPTIONS / HTTP/1.1
> Host: localhost:4000
> User-Agent: curl/7.54.0
> Accept: */*
> Origin: http://foo.bar
> Access-Control-Request-Method: POST
>
< HTTP/1.1 200 OK
< cache-control: max-age=0, private, must-revalidate
< content-length: 0
< date: Wed, 29 May 2019 18:43:27 GMT
< server: Cowboy
```

## After

```shell
> curl --request OPTIONS --header "Origin: http://foo.bar" --header "Access-Control-Request-Method: POST" --verbose http://localhost:4000
…
> OPTIONS / HTTP/1.1
> Host: localhost:4000
> User-Agent: curl/7.54.0
> Accept: */*
> Origin: http://foo.bar
> Access-Control-Request-Method: POST
>
< HTTP/1.1 200 OK
< access-control-allow-headers: 
< access-control-allow-methods: PUT, PATCH, DELETE
< access-control-allow-origin: *
< cache-control: max-age=0, private, must-revalidate
< content-length: 0
< date: Wed, 29 May 2019 18:41:29 GMT
< server: Cowboy
```