### PR TITLE
Add fully-functional Ecto error messages handling

### DIFF
--- a/lib/elixir_boilerplate_web/errors/helpers.ex
+++ b/lib/elixir_boilerplate_web/errors/helpers.ex
@@ -1,43 +1,59 @@
 defmodule ElixirBoilerplateWeb.Errors.Helpers do
-  @moduledoc """
-  Conveniences for translating and building error messages.
-  """
-  use Phoenix.HTML
+  alias Ecto.Changeset
+  alias ElixirBoilerplateWeb.Errors.View
 
   @doc """
-  Generates tag for inlined form input errors.
+  Generates a human-readable block containing all errors in a changeset. Errors
+  are then localized using translations in the `ecto` domain.
+
+  For example, you could have an `ecto.po` file in the french locale:
+
+  ```
+  msgid ""
+  msgstr ""
+  "Language: fr"
+
+  msgid "can't be blank"
+  msgstr "ne peut être vide"
+  ```
   """
-  def error_tag(form, field) do
-    Enum.map(Keyword.get_values(form.errors, field), fn error ->
-      content_tag(:span, translate_error(error))
+  def error_messages(changeset) do
+    changeset
+    |> Changeset.traverse_errors(&translate_error/1)
+    |> convert_errors_to_html(changeset.data.__struct__)
+  end
+
+  defp translate_error({message, options}) do
+    if options[:count] do
+      Gettext.dngettext(ElixirBoilerplate.Gettext, "ecto", message, message, options[:count], options)
+    else
+      Gettext.dgettext(ElixirBoilerplate.Gettext, "ecto", message, options)
+    end
+  end
+
+  defp convert_errors_to_html(errors, schema) do
+    errors = Enum.reduce(errors, [], &convert_error_field(&1, &2, schema))
+    View.render("error_messages.html", %{errors: errors})
+  end
+
+  defp convert_error_field({field, errors}, memo, schema) when is_list(errors), do: memo ++ Enum.flat_map(errors, &convert_error_subfield(&1, field, [], schema))
+  defp convert_error_field({field, errors}, memo, schema) when is_map(errors), do: memo ++ Enum.flat_map(Map.keys(errors), &convert_error_subfield(&1, field, errors[&1], schema))
+
+  defp convert_error_subfield(message, field, _, _schema) when is_binary(message) do
+    # NOTE `schema` is available here if we want to use something like
+    # `schema.humanize_field(field)` to be able to display `"Email address is
+    # invalid"` instead of `email is invalid"`.
+    ["#{field} #{message}"]
+  end
+
+  defp convert_error_subfield(message, field, memo, schema) when is_map(message) do
+    Enum.reduce(message, memo, fn {subfield, errors}, memo ->
+      memo ++ convert_error_field({"#{field}.#{subfield}", errors}, memo, schema)
     end)
   end
 
-  @doc """
-  Translates an error message using gettext.
-  """
-  def translate_error({msg, opts}) do
-    # When using gettext, we typically pass the strings we want
-    # to translate as a static argument:
-    #
-    #     # Translate "is invalid" in the "errors" domain
-    #     dgettext("errors", "is invalid")
-    #
-    #     # Translate the number of files with plural rules
-    #     dngettext("errors", "1 file", "%{count} files", count)
-    #
-    # Because the error messages we show in our forms and APIs
-    # are defined inside Ecto, we need to translate them dynamically.
-    # This requires us to call the Gettext module passing our gettext
-    # backend as first argument.
-    #
-    # Note we use the "errors" domain, which means translations
-    # should be written to the errors.po file. The :count option is
-    # set by Ecto and indicates we should also apply plural rules.
-    if count = opts[:count] do
-      Gettext.dngettext(ElixirBoilerplateWeb.Gettext, "errors", msg, msg, count, opts)
-    else
-      Gettext.dgettext(ElixirBoilerplateWeb.Gettext, "errors", msg, opts)
-    end
+  defp convert_error_subfield(subfield, field, errors, schema) do
+    field = "#{field}.#{subfield}"
+    convert_error_field({field, errors}, [], schema)
   end
 end

--- a/lib/elixir_boilerplate_web/errors/templates/error_messages.html.eex
+++ b/lib/elixir_boilerplate_web/errors/templates/error_messages.html.eex
@@ -1,0 +1,7 @@
+<%= if @errors != [] do %>
+  <ul>
+    <%= for error <- @errors do %>
+      <li><%= error %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/lib/elixir_boilerplate_web/errors/view.ex
+++ b/lib/elixir_boilerplate_web/errors/view.ex
@@ -1,5 +1,5 @@
 defmodule ElixirBoilerplateWeb.Errors.View do
-  use Phoenix.View, root: "lib/elixir_boilerplate_web", namespace: ElixirBoilerplateWeb
+  use Phoenix.View, root: "lib/elixir_boilerplate_web", path: "errors/templates", namespace: ElixirBoilerplateWeb
 
   def template_not_found(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)

--- a/test/elixir_boilerplate_web/errors/helpers_test.exs
+++ b/test/elixir_boilerplate_web/errors/helpers_test.exs
@@ -1,0 +1,79 @@
+defmodule ElixirBoilerplateWeb.Errors.HelpersTest do
+  use ElixirBoilerplate.DataCase, async: true
+
+  alias ElixirBoilerplateWeb.Errors.Helpers
+
+  defmodule UserRole do
+    use Ecto.Schema
+
+    import Ecto.Changeset
+
+    embedded_schema do
+      field(:type, :string)
+
+      timestamps()
+    end
+
+    def changeset(%__MODULE__{} = user_role, params) do
+      user_role
+      |> cast(params, [:type])
+      |> validate_required([:type])
+      |> validate_inclusion(:type, ~w(admin moderator member))
+    end
+  end
+
+  defmodule User do
+    use Ecto.Schema
+
+    import Ecto.Changeset
+
+    schema "users" do
+      field(:email, :string)
+
+      embeds_one(:single_role, UserRole)
+      embeds_many(:multiple_roles, UserRole)
+
+      timestamps()
+    end
+
+    def changeset(%__MODULE__{} = user, params) do
+      user
+      |> cast(params, [:email])
+      |> cast_embed(:single_role)
+      |> cast_embed(:multiple_roles)
+      |> validate_length(:email, is: 10)
+      |> validate_format(:email, ~r/@/)
+    end
+  end
+
+  test "error_messages/1 without errors should return an empty string" do
+    html =
+      %User{}
+      |> change()
+      |> changeset_to_error_messages()
+
+    assert html == ""
+  end
+
+  test "error_messages/1 should render error messages on changeset" do
+    html =
+      %User{}
+      |> User.changeset(%{"email" => "foo", "single_role" => %{"type" => "bar"}, "multiple_roles" => [%{"type" => ""}]})
+      |> changeset_to_error_messages()
+
+    assert html == """
+             <ul>
+                 <li>email has invalid format</li>
+                 <li>email should be 10 character(s)</li>
+                 <li>multiple_roles.type can&#39;t be blank</li>
+                 <li>single_role.type is invalid</li>
+             </ul>
+           """
+  end
+
+  defp changeset_to_error_messages(changeset) do
+    changeset
+    |> Helpers.error_messages()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end


### PR DESCRIPTION
This is the helper module we use in a few projects to handle Ecto error messages.

We can use it this way:

```eex
<%= if @changeset.action do %>
  <%= error_messages(@changeset) %>
<% end %>
```

to output something like:

```html
<ul>
  <li>email is invalid</li>
  <li>email is already taken</li>
  <li>role.type is not valid</li>
</ul>
```

I added basic tests but I’ll keep on adding more before merging because it doesn’t fully support “many” fields like `has_many` and `embeds_many` associations.