### PR TITLE
Add “mix check.unused_locked_deps” task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ check-format:
 check-typespecs:
 	mix dialyzer --halt-exit-status --format dialyxir
 
+.PHONY: check-unused-locked-dependencies
+check-unused-locked-dependencies:
+	mix check.unused_locked_deps
+
 .PHONY: format
 format: ## Format project files
 	mix format

--- a/lib/mix/tasks/check.erlang_version.ex
+++ b/lib/mix/tasks/check.erlang_version.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Erlang.CheckVersion do
+defmodule Mix.Tasks.Check.ErlangVersion do
   use Mix.Task
 
   @shortdoc "Check the Erlang/OTP version"

--- a/lib/mix/tasks/check.unused_locked_deps.ex
+++ b/lib/mix/tasks/check.unused_locked_deps.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.Check.UnusedLockedDeps do
+  use Mix.Task
+
+  @shortdoc "Check if there are unused locked dependencies"
+
+  @impl true
+  def run(_) do
+    used_apps =
+      []
+      |> Mix.Dep.load_on_environment()
+      |> Enum.map(& &1.app)
+      |> MapSet.new()
+
+    locked_apps =
+      Mix.Dep.Lock.read()
+      |> Map.keys()
+      |> MapSet.new()
+
+    used_locked_apps = MapSet.intersection(used_apps, locked_apps)
+
+    unused_locked_apps =
+      locked_apps
+      |> MapSet.difference(used_locked_apps)
+      |> MapSet.to_list()
+
+    if unused_locked_apps != [] do
+      apps = Enum.map_join(unused_locked_apps, "\n", &"  #{&1}")
+
+      Mix.raise("There are some unused dependencies in the lockfile. Run `mix deps.unlock --unused` to unlock them.\n#{apps}")
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -78,7 +78,7 @@ defmodule ElixirBoilerplate.Mixfile do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"],
-      "compile.app": ["erlang.check_version", "compile.app"]
+      "compile.app": ["check.erlang_version", "compile.app"]
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -36,13 +36,10 @@
   "plug_canonical_host": {:hex, :plug_canonical_host, "0.6.0", "c0c7c9d0f31e81b0d6a6e6a414070151d57425b196539f8e294dfc035312c9da", [:mix], [{:plug, " ~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_cowboy": {:hex, :plug_cowboy, "2.0.2", "6055f16868cc4882b24b6e1d63d2bada94fb4978413377a3b32ac16c18dffba2", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.14.1", "63247d4a5ad6b9de57a0bac5d807e1c32d41e39c04b8a4156a26c63bcd8a2e49", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "sentry": {:hex, :sentry, "7.0.5", "31531b7218d6932dc32c4180a153ec9c2485da019868c666190bca522ce083c8", [:mix], [{:hackney, "~> 1.8 or 1.6.5", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix, "~> 1.3", [hex: :phoenix, repo: "hexpm", optional: true]}, {:plug, "~> 1.6", [hex: :plug, repo: "hexpm", optional: true]}, {:plug_cowboy, "~> 1.0 or ~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: true]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.2.0", "5b40caa3efe4deb30fb12d7cd8ed4f556f6d6bd15c374c2366772161311ce377", [:mix], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
 }

--- a/priv/scripts/ci-check.sh
+++ b/priv/scripts/ci-check.sh
@@ -48,6 +48,9 @@ run mix run priv/repo/seeds.exs
 header "Run dummy data…"
 run mix run priv/repo/dummy.exs
 
+header "Check unused locked dependencies…"
+run make check-unused-locked-dependencies
+
 header "Build Docker image…"
 run make build
 


### PR DESCRIPTION
We want to avoid keeping unused dependencies in `mix.lock`. This pull request adds a new `check.unused_locked_deps` that is used in the CI build.

I also renamed our other check `erlang.check_version` to `check.erlang_version` in order to keep things consistent 😄

Also, there were three unused deps in `mix.lock` 🙄