### PR TITLE
Add “AvoidSpecificTermsInModuleNames” check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -55,6 +55,7 @@
         {Credo.Check.Warning.UnusedTupleOperation},
         {Credo.Check.Warning.OperationWithConstantResult},
         {CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime},
+        {CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames, terms: ["Manager", "Fetcher", "Builder", "Persister", "Serializer", "Helper", "Helpers", "Utils"]},
         {CredoNaming.Check.Consistency.ModuleFilename, excluded_paths: ["config", "mix.exs", "priv", "test/support"]}
       ]
     }

--- a/lib/elixir_boilerplate_web/errors/errors.ex
+++ b/lib/elixir_boilerplate_web/errors/errors.ex
@@ -1,4 +1,4 @@
-defmodule ElixirBoilerplateWeb.Errors.Helpers do
+defmodule ElixirBoilerplateWeb.Errors do
   alias Ecto.Changeset
   alias ElixirBoilerplateWeb.Errors.View
 

--- a/test/elixir_boilerplate_web/errors_test.exs
+++ b/test/elixir_boilerplate_web/errors_test.exs
@@ -1,7 +1,7 @@
-defmodule ElixirBoilerplateWeb.Errors.HelpersTest do
+defmodule ElixirBoilerplateWeb.ErrorsTest do
   use ElixirBoilerplate.DataCase, async: true
 
-  alias ElixirBoilerplateWeb.Errors.Helpers
+  alias ElixirBoilerplateWeb.Errors
 
   defmodule UserRole do
     use Ecto.Schema
@@ -73,7 +73,7 @@ defmodule ElixirBoilerplateWeb.Errors.HelpersTest do
 
   defp changeset_to_error_messages(changeset) do
     changeset
-    |> Helpers.error_messages()
+    |> Errors.error_messages()
     |> Phoenix.HTML.safe_to_string()
   end
 end


### PR DESCRIPTION
Now that we’re using [`credo_naming`](https://github.com/mirego/credo_naming), we can take advantage of its other checks.

This pull requests adds the `CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames` check, which can prevent us from using OOP-style terms in our module names.

Here is the list of terms I’m suggesting we use for the moment:

* `Manager`
* `Fetcher`
* `Builder`
* `Persister`
* `Serializer`
* `Helper`
* `Helpers`

I think this will make it easier for us to stick to our [naming guidelines](https://github.com/mirego/elixir-boilerplate/blob/master/docs/module-naming.fr.md).