### PR TITLE
Make the majority of environment variables required for dev and prod

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -26,6 +26,7 @@ SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
 # - Use `postgres://postgres:development@localhost/elixir_boilerplate_dev` if you’re using the PostgreSQL server provided by Docker Compose
 DATABASE_URL=postgres://localhost/elixir_boilerplate_dev
 DATABASE_POOL_SIZE=20
+DATABASE_SSL=false
 
 # Basic Authentication
 # BASIC_AUTH_USERNAME=

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -5,25 +5,32 @@ defmodule Environment do
   This modules provides various helpers to handle environment metadata
   """
 
-  def get(key), do: System.get_env(key)
+  def get(key, opts \\ []) do
+    optional = Keyword.get(opts, :optional, false)
 
-  def get_boolean(key) do
-    case get(key) do
+    case {System.get_env(key), optional, Mix.env()} do
+      {nil, false, env} when env != :test -> raise("The application cannot start without a value for the `#{key}` environment variable.")
+      {value, _, _} -> value
+    end
+  end
+
+  def get_boolean(key, opts \\ []) do
+    case get(key, opts) do
       "true" -> true
       "1" -> true
       _ -> false
     end
   end
 
-  def get_integer(key) do
-    case get(key) do
+  def get_integer(key, opts \\ []) do
+    case get(key, opts) do
       value when is_bitstring(value) -> String.to_integer(value)
       _ -> nil
     end
   end
 
-  def get_list_or_first_value(key) do
-    with value when is_bitstring(value) <- get(key),
+  def get_list_or_first_value(key, opts \\ []) do
+    with value when is_bitstring(value) <- get(key, opts),
          [single_value] <- String.split(value, ",") do
       single_value
     else
@@ -54,9 +61,9 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   session_key: Environment.get("SESSION_KEY"),
   signing_salt: Environment.get("SIGNING_SALT"),
   static_url: [
-    scheme: Environment.get("STATIC_URL_SCHEME"),
-    host: Environment.get("STATIC_URL_HOST"),
-    port: Environment.get("STATIC_URL_PORT")
+    scheme: Environment.get("STATIC_URL_SCHEME", optional: true),
+    host: Environment.get("STATIC_URL_HOST", optional: true),
+    port: Environment.get("STATIC_URL_PORT", optional: true)
   ],
   url: [scheme: scheme, host: host, port: port]
 
@@ -64,10 +71,10 @@ config :elixir_boilerplate, Corsica, origins: Environment.get_list_or_first_valu
 
 config :elixir_boilerplate,
   basic_auth: [
-    username: Environment.get("BASIC_AUTH_USERNAME"),
-    password: Environment.get("BASIC_AUTH_PASSWORD")
+    username: Environment.get("BASIC_AUTH_USERNAME", optional: true),
+    password: Environment.get("BASIC_AUTH_PASSWORD", optional: true)
   ]
 
 config :sentry,
-  dsn: Environment.get("SENTRY_DSN"),
-  environment_name: Environment.get("SENTRY_ENVIRONMENT_NAME")
+  dsn: Environment.get("SENTRY_DSN", optional: true),
+  environment_name: Environment.get("SENTRY_ENVIRONMENT_NAME", optional: true)


### PR DESCRIPTION
Since we provide all required environment variables in `.env.dev` and most of them are required for the application to start, we could actually _enforce_ them in order to get an explicit error message if one of them is missing.

@simonprev @gcauchon @paquetgp What do you think? Is it a terrible idea? Is there something missing?