### PR TITLE
Improve Content-Security-Policy value

### DIFF
--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -7,6 +7,6 @@
   format: "txt",
   out: "",
   threshold: "low",
-  ignore: ["Config.HTTPS"],
+  ignore: ["Config.HTTPS", "Config.CSP"],
   ignore_files: [""]
 ]

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -11,6 +11,10 @@
 .home a {
   display: block;
   margin: 0 0 20px;
+  text-decoration: none;
+  font-size: 40px;
+  font-weight: bold;
+  color: #3a186a;
 }
 
 .home p {

--- a/lib/elixir_boilerplate_web/home/templates/index.html.eex
+++ b/lib/elixir_boilerplate_web/home/templates/index.html.eex
@@ -1,6 +1,6 @@
 <div class="home">
-  <a target="_blank" href="https://github.com/mirego/elixir-boilerplate">
-    <img src="https://user-images.githubusercontent.com/11348/52080254-520cb580-2565-11e9-8c21-156cf0b7bcf3.png" width="500" />
+  <a target="_blank" href="https://github.com/mirego/elixir-boilerplate" class="logo">
+    Elixir Boilerplate
   </a>
 
   <p>This repository is the stable base upon which we build our Elixir projects at Mirego.<br />We want to share it with the world so you can build awesome Elixir applications too.</p>

--- a/lib/elixir_boilerplate_web/router.ex
+++ b/lib/elixir_boilerplate_web/router.ex
@@ -1,8 +1,6 @@
 defmodule ElixirBoilerplateWeb.Router do
   use Phoenix.Router
 
-  @secure_headers %{"content-security-policy" => "default-src 'self'"}
-
   pipeline :api do
     plug(:accepts, ["json"])
   end
@@ -12,7 +10,8 @@ defmodule ElixirBoilerplateWeb.Router do
     plug(:fetch_session)
     plug(:fetch_flash)
     plug(:protect_from_forgery)
-    plug(:put_secure_browser_headers, @secure_headers)
+    plug(:put_secure_browser_headers)
+    plug(:put_content_security_policy)
     plug(:put_layout, {ElixirBoilerplateWeb.Layouts.View, :app})
   end
 
@@ -20,5 +19,22 @@ defmodule ElixirBoilerplateWeb.Router do
     pipe_through(:browser)
 
     get("/", Home.Controller, :index, as: :home)
+  end
+
+  def put_content_security_policy(conn, _) do
+    content_security_policy =
+      Mix.env()
+      |> content_security_policy()
+      |> Enum.join("; ")
+
+    put_resp_header(conn, "content-security-policy", content_security_policy)
+  end
+
+  defp content_security_policy(:dev) do
+    ["default-src 'self'", "script-src 'self' 'unsafe-eval' 'unsafe-inline'", "style-src 'self' 'unsafe-inline'"]
+  end
+
+  defp content_security_policy(_) do
+    ["default-src 'self'"]
   end
 end


### PR DESCRIPTION
We implemented a default `Content-Security-Policy` value in #64 but it did added a lot for console errors in development.

It also prevented the demo homepage from loading the project logo from `user-images.githubusercontent.com`.

So now we implement some default directives for script and styles that are compatible with Phoenix development stuff and we replaced the logo image for a simple text logo.

I also had to disable the `Config.CSP` Sobelow check because we put the header in a separate plug.

![](https://user-images.githubusercontent.com/11348/62166705-7caab180-b2ef-11e9-987e-857c95f8a830.png)
