### PR TITLE
Ditch deprecated Supervisor.Spec module

### DIFF
--- a/lib/elixir_boilerplate/application.ex
+++ b/lib/elixir_boilerplate/application.ex
@@ -4,15 +4,11 @@ defmodule ElixirBoilerplate.Application do
   """
 
   use Application
-  alias ElixirBoilerplate.Repo
-  alias ElixirBoilerplateWeb.Endpoint
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      supervisor(Repo, []),
-      supervisor(Endpoint, [])
+      ElixirBoilerplate.Repo,
+      ElixirBoilerplateWeb.Endpoint
     ]
 
     {:ok, _} = Logger.add_backend(Sentry.LoggerBackend)
@@ -22,7 +18,7 @@ defmodule ElixirBoilerplate.Application do
   end
 
   def config_change(changed, _new, removed) do
-    Endpoint.config_change(changed, removed)
+    ElixirBoilerplateWeb.Endpoint.config_change(changed, removed)
     :ok
   end
 end


### PR DESCRIPTION
We were still using helper functions from [`Supervisor.Spec`](https://hexdocs.pm/elixir/Supervisor.Spec.html) to build the main supervisor tree.

> This module is deprecated. Use the new child specifications outlined in the Supervisor module instead.
> 
> Outdated functions for building child specifications.
> 
> The functions in this module are deprecated and they do not work with the module-based child specs introduced in Elixir v1.5. Please see the Supervisor documentation instead.
> 
> Convenience functions for defining supervisor specifications.