### PR TITLE
Simplify grep command to extract application name and version from mix.exs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Build configuration
 # -------------------
 
-APP_NAME = `grep 'app:' mix.exs | sed -e 's/\[//g' -e 's/ //g' -e 's/app://' -e 's/[:,]//g'`
-APP_VERSION = `grep -E '@version "([0-9\.]*)"' mix.exs | cut -d '"' -f2`
+APP_NAME = `grep -Eo 'app: :\w*' mix.exs | cut -d ':' -f 3`
+APP_VERSION = `grep -Eo '@version "[0-9\.]*"' mix.exs | cut -d '"' -f 2`
 GIT_REVISION = `git rev-parse HEAD`
 DOCKER_IMAGE_TAG ?= latest
 DOCKER_REGISTRY ?=


### PR DESCRIPTION
Since #67, we are using a _module attribute_ for the application version. The _regex-based_ `grep` command was introduced, but the one to get the application name was still using a weird `grep` and `sed` combination… 