### PR TITLE
Ensure `:ssl` is started before Ecto.Migrator is ran

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,6 +12,8 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   pubsub: [name: ElixirBoilerplate.PubSub, adapter: Phoenix.PubSub.PG2],
   render_errors: [view: ElixirBoilerplateWeb.Errors.View, accepts: ~w(html json)]
 
+config :elixir_boilerplate, ElixirBoilerplate.Repo, start_apps_before_migration: [:ssl]
+
 config :elixir_boilerplate, Corsica, allow_headers: :all
 
 config :elixir_boilerplate, ElixirBoilerplate.Gettext, default_locale: "en"

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -45,8 +45,7 @@ config :elixir_boilerplate,
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
   pool_size: Environment.get_integer("DATABASE_POOL_SIZE"),
   ssl: Environment.get_boolean("DATABASE_SSL"),
-  url: Environment.get("DATABASE_URL"),
-  start_apps_before_migration: if(Environment.get_boolean("DATABASE_SSL"), do: [:ssl], else: [])
+  url: Environment.get("DATABASE_URL")
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -45,7 +45,8 @@ config :elixir_boilerplate,
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
   pool_size: Environment.get_integer("DATABASE_POOL_SIZE"),
   ssl: Environment.get_boolean("DATABASE_SSL"),
-  url: Environment.get("DATABASE_URL")
+  url: Environment.get("DATABASE_URL"),
+  start_apps_before_migration: if(Environment.get_boolean("DATABASE_SSL"), do: [:ssl], else: [])
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),


### PR DESCRIPTION
If an `Ecto.Repo` is configured with `ssl: true`, we have to make sure the `:ssl` application is started before `Ecto.Migrator` is used (eg. when the application is started).