### PR TITLE
Fix empty Absinthe context

### DIFF
--- a/lib/elixir_boilerplate_graphql/router.ex
+++ b/lib/elixir_boilerplate_graphql/router.ex
@@ -7,9 +7,10 @@ defmodule ElixirBoilerplateGraphQL.Router do
     schema: ElixirBoilerplateGraphQL.Schema
   ]
 
+  plug(ElixirBoilerplateGraphQL.Plugs.Context)
+
   plug(:match)
   plug(:dispatch)
-  plug(ElixirBoilerplateGraphQL.Plugs.Context)
 
   forward("/graphql",
     to: Absinthe.Plug,


### PR DESCRIPTION
For reason unknown to my knowledge, using the context plug after `dispatch` prevent the context from being populated. The order has been [changed recently](https://github.com/mirego/elixir-boilerplate/commit/6747a2a4e38376d88277b12ff64b74fdfc5064d3#diff-8718fe63175e93ad62609310fa049129R12).

I’ve read the dispatch plug code and couldn’t understand why 🤷‍♂ 