### PR TITLE
Fix coveralls exclusion path for version check mix task

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -4,7 +4,8 @@
   },
   "skip_files": [
     "lib/elixir-boilerplate/release_tasks.ex",
-    "lib/mix/tasks/erlang.check_version.ex",
+    "lib/mix/tasks/check.erlang_version.ex",
+    "lib/mix/tasks/check.unused_locked_deps.ex",
     "test/support"
   ]
 }


### PR DESCRIPTION
The path for the `erlang_version` check wasn’t correct. At the same time, I’ve added the new task to the exclusion list as well.