### PR TITLE
Add a new makefile's command to easily start the server

### DIFF
--- a/BOILERPLATE_README.fr.md
+++ b/BOILERPLATE_README.fr.md
@@ -45,7 +45,7 @@ Ces variables doivent être présentes dans l’environnement lorsque des comman
 Ensuite, avec les variables de `.env.dev` et `.env.dev.local` présentes dans l’environnement :
 
 1. Créer et migrer la base de données avec `mix ecto.setup`
-2. Démarrer le serveur Phoenix avec `iex -S mix phx.server`
+2. Démarrer le serveur Phoenix avec `make run`
 
 ### Commandes `make`
 

--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -45,7 +45,7 @@ When running `mix` or `make` commands, it is important that these variables are 
 Then, with variables from `.env.dev` and `.env.dev.local` present in the environment:
 
 4. Create and migrate the database with `mix ecto.setup`
-5. Start the Phoenix server with `iex -S mix phx.server` with environment variables from `.env.dev` and `.env.dev.local`
+5. Start the Phoenix server with `make run`
 
 ### `make` commands
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ push: ## Push the Docker image
 # Development targets
 # -------------------
 
+.PHONY: run
+run: ## Run the server as IEX
+	iex -S mix phx.server
+
 .PHONY: dependencies
 dependencies: ## Install dependencies required by the application
 	mix deps.get --force

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ push: ## Push the Docker image
 # -------------------
 
 .PHONY: run
-run: ## Run the server as IEX
+run: ## Run the server inside an IEx shell
 	iex -S mix phx.server
 
 .PHONY: dependencies


### PR DESCRIPTION
## 📖 Description

To ease the process of starting the Phoenix server, let's use the makefile to isolate the knowledge by exposing a `run` command. 