### PR TITLE
Add Credo.Check.Readability.MultiAlias check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -24,6 +24,7 @@
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc, false},
         {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.MultiAlias},
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},
         {Credo.Check.Readability.SinglePipe},

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -14,7 +14,8 @@ defmodule ElixirBoilerplate.DataCase do
 
   use ExUnit.CaseTemplate
 
-  alias Ecto.{Adapters.SQL.Sandbox, Changeset}
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Changeset
   alias ElixirBoilerplate.Repo
 
   using do


### PR DESCRIPTION
To ensure optimal code “greppability” in the project, we’re adding the [`Credo.Check.Readability.MultiAlias`](https://github.com/rrrene/credo/blob/master/lib/credo/check/readability/multi_alias.ex) Credo check which disallow the usage of alias expansion.