### PR TITLE
Update the runtime image to Alpine 3.10 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir -p /opt/build && \
 #
 # Step 3 - build a lean runtime container
 #
-FROM alpine:3.9
+FROM alpine:3.10
 
 ARG APP_NAME
 ENV APP_NAME=${APP_NAME}


### PR DESCRIPTION
`erlang:22-alpine`, the base image for `elixir:1.9-alpine`, was updated to Erlang `22.1` and Alpine `3.10` on September 17th.

https://github.com/erlang/docker-erlang-otp/commit/daa8c85d275ac3b555f7bdadc8c5df24bc6a75a0

We are packaging the OTP release for `3.10`, so we need to update the runtime Alpine image to `3.10` too!