### PR TITLE
Improve Docker-related environment variables in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2020-01-22
+
+### Updated
+
+- Improve Docker-related environment variables in Makefile (#86)
+
 ## 2019-12-19
 
 ### Added

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2019, Mirego
+Copyright (c) 2017-2020, Mirego
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@
 APP_NAME = `grep -Eo 'app: :\w*' mix.exs | cut -d ':' -f 3`
 APP_VERSION = `grep -Eo '@version "[0-9\.]*"' mix.exs | cut -d '"' -f 2`
 GIT_REVISION = `git rev-parse HEAD`
-DOCKER_IMAGE_TAG ?= latest
+DOCKER_IMAGE_TAG ?= $(APP_VERSION)
 DOCKER_REGISTRY ?=
+DOCKER_LOCAL_IMAGE = $(APP_NAME):$(DOCKER_IMAGE_TAG)
+DOCKER_REMOTE_IMAGE = $(DOCKER_REGISTRY)/$(DOCKER_LOCAL_IMAGE)
 
 # Linter and formatter configuration
 # ----------------------------------
@@ -37,6 +39,12 @@ header:
 	@echo ""
 	@printf "\033[33m%-23s\033[0m" "DOCKER_REGISTRY"
 	@printf "\033[35m%s\033[0m" $(DOCKER_REGISTRY)
+	@echo ""
+	@printf "\033[33m%-23s\033[0m" "DOCKER_LOCAL_IMAGE"
+	@printf "\033[35m%s\033[0m" $(DOCKER_LOCAL_IMAGE)
+	@echo ""
+	@printf "\033[33m%-23s\033[0m" "DOCKER_REMOTE_IMAGE"
+	@printf "\033[35m%s\033[0m" $(DOCKER_REMOTE_IMAGE)
 	@echo "\n"
 
 .PHONY: targets
@@ -50,12 +58,12 @@ targets:
 
 .PHONY: build
 build: ## Build the Docker image for the OTP release
-	docker build --build-arg APP_NAME=$(APP_NAME) --build-arg APP_VERSION=$(APP_VERSION) --rm --tag $(APP_NAME):$(DOCKER_IMAGE_TAG) .
+	docker build --build-arg APP_NAME=$(APP_NAME) --build-arg APP_VERSION=$(APP_VERSION) --rm --tag $(DOCKER_LOCAL_IMAGE) .
 
 .PHONY: push
-push: ## Push the Docker image
-	docker tag $(APP_NAME):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/$(APP_NAME):$(DOCKER_IMAGE_TAG)
-	docker push $(DOCKER_REGISTRY)/$(APP_NAME):$(DOCKER_IMAGE_TAG)
+push: ## Push the Docker image to the registry
+	docker tag $(DOCKER_LOCAL_IMAGE) $(DOCKER_REMOTE_IMAGE)
+	docker push $(DOCKER_REMOTE_IMAGE)
 
 # Development targets
 # -------------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This boilerplate comes with batteries included, you’ll find:
 
 ## License
 
-Elixir Boilerplate is © 2017-2019 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/elixir-boilerplate/blob/master/LICENSE.md) file.
+Elixir Boilerplate is © 2017-2020 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/elixir-boilerplate/blob/master/LICENSE.md) file.
 
 The drop logo is based on [this lovely icon by Creative Stall](https://thenounproject.com/term/drop/174999), from The Noun Project. Used under a [Creative Commons BY 3.0](http://creativecommons.org/licenses/by/3.0/) license.
 


### PR DESCRIPTION
We now have simpler and clearer Docker-related environment variables in our `Makefile`

```bash
$ DOCKER_REGISTRY=gcr.io/foo make

# Environment
# ---------------------------------------------------------------
# APP_NAME               elixir_boilerplate
# APP_VERSION            0.0.1
# GIT_REVISION           2820a390642b542f044d9141f8f3e9686a4dedef
# DOCKER_IMAGE_TAG       0.0.1
# DOCKER_REGISTRY        gcr.io/foo
# DOCKER_LOCAL_IMAGE     elixir_boilerplate:0.0.1
# DOCKER_REMOTE_IMAGE    gcr.io/foo/elixir_boilerplate:0.0.1
```