### PR TITLE
Fix snake_case regex in boilerplate setup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Since it is a boilerplate project, there are technically no official (versioned)
 ### Fixed
 
 - `make` targets using `npx` now work properly since we now change the current working directory to `assets` before running them
+- The `boilerplate-setup.sh` script now supports PascalCase name with consecutive uppercase letters (eg. `FooBarBBQ` → `foo_bar_bbq`)
 
 ## 2020-03-18
 

--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -47,7 +47,7 @@ if [[ -z "$1" ]] ; then
 fi
 
 pascalCaseAfter=$1
-snakeCaseAfter=$(echo $pascalCaseAfter | /usr/bin/sed 's/\(.\)\([A-Z]\)/\1_\2/g' | tr '[:upper:]' '[:lower:]')
+snakeCaseAfter=$(echo $pascalCaseAfter | /usr/bin/sed 's/\(.\)\([A-Z]\{1,\}\)/\1_\2/g' | tr '[:upper:]' '[:lower:]')
 kebabCaseAfter=$(echo $snakeCaseAfter | tr '_' '-')
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The regex to convert a `PascalCase` name into a `snake_case` was not able to support consecutive uppercase letters :

```bash
$ ./boilerplate-setup.sh FooBarBBQ

▶ Configuration
ElixirBoilerplate → FooBarBBQ
elixir_boilerplate → foo_bar_bb_q
elixir-boilerplate → foo-bar-bb-q
```

But now it does:


```bash
$ ./boilerplate-setup.sh FooBarBBQ

▶ Configuration
ElixirBoilerplate → FooBarBBQ
elixir_boilerplate → foo_bar_bbq
elixir-boilerplate → foo-bar-bbq
```

Fixes #95 