### PR TITLE
Fix README.md dependencies and rename script

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,4 +8,7 @@
 # -----------------------------------------------------------------------------
 
 # Database configuration
+# - Use `postgres://localhost/elixir_boilerplate_test` if you have a local PostgreSQL server
+# - Use `postgres://username:password@localhost/elixir_boilerplate_test` if you have a local PostgreSQL server with credentials
+# - Use `postgres://postgres:development@localhost/elixir_boilerplate_test` if you’re using the PostgreSQL server provided by Docker Compose
 DATABASE_URL=

--- a/BOILERPLATE_README.fr.md
+++ b/BOILERPLATE_README.fr.md
@@ -22,11 +22,11 @@
 
 ## 🚧 Dépendances
 
-- Node.js (`>= 10.16, < 11.0`)
-- NPM (`>= 6.9, < 7.0`)
-- Elixir (`~> 1.9`)
-- Erlang (`~> 22.0`)
-- PostgreSQL (`~> 10.0`)
+- Node.js (`>= 12.15, < 13.0`)
+- NPM (`>= 6.13, < 7.0`)
+- Elixir (`~> 1.10`)
+- Erlang (`~> 22.2`)
+- PostgreSQL (`~> 12.0`)
 
 ## 🏎 Départ rapide
 

--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -22,11 +22,11 @@
 
 ## 🚧 Dependencies
 
-- Node.js (`>= 10.16, < 11.0`)
-- NPM (`>= 6.9, < 7.0`)
-- Elixir (`~> 1.9`)
-- Erlang (`~> 22.0`)
-- PostgreSQL (`~> 10.0`)
+- Node.js (`>= 12.15, < 13.0`)
+- NPM (`>= 6.13, < 7.0`)
+- Elixir (`~> 1.10`)
+- Erlang (`~> 22.2`)
+- PostgreSQL (`~> 12.0`)
 
 ## 🏎 Kickstart
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Since it is a boilerplate project, there are technically no official (versioned)
 
 - `make` targets using `npx` now work properly since we now change the current working directory to `assets` before running them
 - The `boilerplate-setup.sh` script now supports PascalCase name with consecutive uppercase letters (eg. `FooBarBBQ` → `foo_bar_bbq`)
+- The `boilerplate-setup.sh` script now takes into account deeper hierarchy files and the Github Action CI workflow file
+- The `BOILERPLATE_README.fr.md` and `BOILERPLATE_README.md` now list the correct dependencies
 
 ### Added
 

--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -17,6 +17,7 @@ content=$(find . -type f \( \
   -name "*.json" -or \
   -name "*.js" -or \
   -name "*.yml" -or \
+  -name "*.yaml" -or \
   -name "*.md" -or \
   -name ".env.*" -or \
   -name "Dockerfile" -or \
@@ -30,11 +31,15 @@ content=$(find . -type f \( \
 
 # The identifiers above will be replaced in the path of the files and directories found here
 paths=$(find . -depth 2 \( \
-  -path "./lib/${snakeCaseBefore}*" -or \
+  -path "./lib/${snakeCaseBefore}" -or \
   -path "./lib/${snakeCaseBefore}_*" -or \
-  -path "./lib/${snakeCaseBefore}.*" -or \
   -path "./test/${snakeCaseBefore}" -or \
   -path "./test/${snakeCaseBefore}_*" \
+\))
+
+files=$(find . \( \
+  -path "./lib/${snakeCaseBefore}.*" -or \
+  -path "./lib/${snakeCaseBefore}*/${snakeCaseBefore}*" \
 \))
 
 # -----------------------------------------------------------------------------
@@ -87,7 +92,14 @@ success "Done!\n"
 
 header "Replacing boilerplate identifiers in file and directory paths"
 for path in $paths; do
-  run mv $path $(echo $path | /usr/bin/sed "s/$snakeCaseBefore/$snakeCaseAfter/g" | /usr/bin/sed "s/$kebabCaseBefore/$kebabCaseAfter/g" | /usr/bin/sed "s/$pascalCaseBefore/$pascalCaseAfter/g")
+  run mkdir $(echo $path | /usr/bin/sed "s/$snakeCaseBefore/$snakeCaseAfter/g" | /usr/bin/sed "s/$kebabCaseBefore/$kebabCaseAfter/g" | /usr/bin/sed "s/$pascalCaseBefore/$pascalCaseAfter/g")
+done
+for file in $files; do \
+  run mv $file $(echo $file | /usr/bin/sed "s/$snakeCaseBefore/$snakeCaseAfter/g" | /usr/bin/sed "s/$kebabCaseBefore/$kebabCaseAfter/g" | /usr/bin/sed "s/$pascalCaseBefore/$pascalCaseAfter/g")
+done
+for path in $paths; do
+  run mv $path/* $(echo $path | /usr/bin/sed "s/$snakeCaseBefore/$snakeCaseAfter/g" | /usr/bin/sed "s/$kebabCaseBefore/$kebabCaseAfter/g" | /usr/bin/sed "s/$pascalCaseBefore/$pascalCaseAfter/g")
+  run rm -rf $path
 done
 success "Done!\n"
 


### PR DESCRIPTION
## 📖 Description

Adjust a few issues found during the integration of a new project:
* Dependencies found in `README.md` were out of sync with newest expected versions
* CI workflow file was not taken into account during setup (renaming)
* Add same notions then `.env.dev` in `.env.test` regarding expected DB URLs
* Fix setup not replacing deeper files in the hierarchy (see results images for details)

## 🦀 Dispatch
		
- `#dispatch/elixir`

## 🎉 Results

| Before | After |
| ------ | ------ |
| <img width="1113" alt="Screen Shot 2020-03-26 at 13 43 39" src="https://user-images.githubusercontent.com/513491/77683115-53215300-6f6e-11ea-9d48-e366da19a312.png"> | <img width="1115" alt="Screen Shot 2020-03-26 at 14 29 48" src="https://user-images.githubusercontent.com/513491/77683116-53b9e980-6f6e-11ea-8544-7dfbf21518a4.png"> |