### PR TITLE
Add a deeper check for DB URL to enforce running against a test DB

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -5,8 +5,6 @@ defmodule Environment do
   This modules provides various helpers to handle environment metadata
   """
 
-  @local_hosts ~w(0.0.0.0 127.0.0.1 localhost host.docker.internal)
-
   def get(key), do: System.get_env(key)
 
   def get_boolean(key) do
@@ -31,15 +29,6 @@ defmodule Environment do
     else
       value when is_list(value) -> value
       _ -> nil
-    end
-  end
-
-  def get_local_url(key) do
-    url = get(key)
-
-    case URI.parse(url).host do
-      host when host in @local_hosts -> url
-      host -> raise "Expected host of the #{key} environment variable to be one of #{Enum.join(@local_hosts, ", ")}, got: #{host}"
     end
   end
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,19 @@ import Config
 # Import runtime configuration
 import_config "releases.exs"
 
+defmodule TestEnvironment do
+  @database_name_suffix "_test"
+
+  def enforce_test_database_name(key) do
+    url = Environment.get_local_url(key)
+
+    case String.contains?(url, @database_name_suffix) do
+      true -> url
+      _ -> raise "Expected database URL to ends with '#{@database_name_suffix}', got: #{url}"
+    end
+  end
+end
+
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   http: [port: 4001],
   server: false,
@@ -24,4 +37,4 @@ config :logger, level: :warn
 
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
-  url: Environment.get_local_url("DATABASE_URL")
+  url: TestEnvironment.enforce_test_database_name("DATABASE_URL")

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,9 +9,10 @@ defmodule TestEnvironment do
   def enforce_test_database_name(key) do
     url = Environment.get_local_url(key)
 
-    case String.contains?(url, @database_name_suffix) do
-      true -> url
-      _ -> raise "Expected database URL to ends with '#{@database_name_suffix}', got: #{url}"
+    if String.contains?(url, @database_name_suffix) do
+      url
+    else
+      raise "Expected database URL to ends with '#{@database_name_suffix}', got: #{url}"
     end
   end
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,8 +6,8 @@ import_config "releases.exs"
 defmodule TestEnvironment do
   @database_name_suffix "_test"
 
-  def enforce_test_database_name(key) do
-    url = Environment.get_local_url(key)
+  def get_test_database_url do
+    url = Environment.get("DATABASE_URL")
 
     if String.contains?(url, @database_name_suffix) do
       url
@@ -38,4 +38,4 @@ config :logger, level: :warn
 
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
-  url: TestEnvironment.enforce_test_database_name("DATABASE_URL")
+  url: TestEnvironment.get_test_database_url()


### PR DESCRIPTION
## 📖 Description

Following the change from @alarochelle in #92, I propose to push the check a little deeper.

While the initial proposal in #92 protects us against erasing production data, the latter protect our local data.

This way, if, by mistake, you do the classic `nv .env.dev.local make test` instead of `nv .env.test.local make test`, it will raise the following:

```bash
** (RuntimeError) Expected database URL to ends with '_test', got: postgres://localhost/elixir_boilerplate_dev
    config/test.exs:14: TestEnvironment.enforce_test_database_name/1
    (stdlib 3.12) erl_eval.erl:680: :erl_eval.do_apply/6
    (stdlib 3.12) erl_eval.erl:888: :erl_eval.expr_list/6
    (stdlib 3.12) erl_eval.erl:240: :erl_eval.expr/5
    (stdlib 3.12) erl_eval.erl:232: :erl_eval.expr/5
    (stdlib 3.12) erl_eval.erl:233: :erl_eval.expr/5
    (stdlib 3.12) erl_eval.erl:888: :erl_eval.expr_list/6
    (stdlib 3.12) erl_eval.erl:411: :erl_eval.expr/5
make: *** [test] Error 1
```

## 🦀 Dispatch
		
- `#dispatch/elixir`