### PR TITLE
Fix pattern in Makefile to run Prettier correctly on Markdown files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DOCKER_REMOTE_IMAGE = $(DOCKER_REGISTRY)/$(DOCKER_LOCAL_IMAGE)
 # Linter and formatter configuration
 # ----------------------------------
 
-PRETTIER_FILES_PATTERN = '.babelrc' 'webpack.config.js' '{js,css,scripts}/**/*.{js,graphql,scss,css}' '**/*.md'
+PRETTIER_FILES_PATTERN = '.babelrc' 'webpack.config.js' '{js,css,scripts}/**/*.{js,graphql,scss,css}' '../*.md' '../*/*.md'
 STYLES_PATTERN = 'css'
 
 # Introspection targets


### PR DESCRIPTION
## 📖 Description

When we [changed file patterns](https://github.com/mirego/elixir-boilerplate/pull/94/files#diff-b67911656ef5d18c4ae36cb6741b7965L15-R16) #94 to use `cd assets && npx prettier …` command, we forgot to adjust the pattern for Markdown files.

We were checking the format for `./assets/**/*.md` but most of our Markdown files are in `./`, `./docs` or `.github`.

## 📝 Notes

I tried to use the wider `../**/*.md` pattern, but I couldn’t get Prettier to ignore files in `../deps` (even by adding `deps` or `../deps` to `assets/.prettierignore` 🤷‍♂) but I think this is good enough.