### PR TITLE
Add documentation for /ping and /health routes

### DIFF
--- a/BOILERPLATE_README.fr.md
+++ b/BOILERPLATE_README.fr.md
@@ -85,7 +85,17 @@ Le script `priv/scripts/ci-check.sh` exécute un ensemble de commantes (tests, _
 
 ## 🚑 Problèmes et solutions
 
-…
+### Disponibilité du système
+
+Le projet expose une route `GET /ping` qui retourne une réponse HTTP `200 OK` dès que le serveur est prêt à recevoir des requêtes. La réponse contient également la version du projet à des fin de déboguage.
+
+### Santé du système
+
+Le projet expose une route `GET /health` qui sert le module `ElixirBoilerplateHealth`. Ce module contient différents _checks_ qui s’assurent que l’application et ses services dépendants sont en santé.
+
+| Nom    | Description                         |
+| ------ | ----------------------------------- |
+| `NOOP` | Check _check_ est toujours en santé |
 
 ## 🚀 Deploiement
 

--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -85,7 +85,17 @@ The `priv/scripts/ci-check.sh` script runs a set of commands (tests, linting, et
 
 ## 🚑 Troubleshooting
 
-…
+### System readiness
+
+The project exposes a `GET /ping` route that sends an HTTP `200 OK` response as soon as the server is ready to accept requests. The response also contains the project version for debugging purpose.
+
+### System health
+
+The project exposes a `GET /health` route that serves the `ElixirBoilerplateHealth` module. This module contains checks to make sure the application and its external dependencies are healthy.
+
+| Name   | Description                  |
+| ------ | ---------------------------- |
+| `NOOP` | This check is always healthy |
 
 ## 🚀 Deploy
 


### PR DESCRIPTION
## 📖 Description

We have two greate routes that were undocumented: `GET /ping` and `GET /health`. I simply added the missing documentation 😄

@pmartel12 Since you’re the one who wrote the `PlugCheckup` implementation, do you think those tables documenting each individual check are valuable?