### PR TITLE
Add PascalCase check in boilerplate setup script

### DIFF
--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -46,8 +46,8 @@ files=$(find . \( \
 # Validation
 # -----------------------------------------------------------------------------
 
-if [[ -z "$1" ]] ; then
-  echo 'You must specify your project name in PascalCase as first argument.'
+if [[ -z $(echo "$1" | grep "^[A-Z]") ]] ; then
+  echo 'You must specify your project name in PascalCase as first argument (eg. FooBar).'
   exit 0
 fi
 


### PR DESCRIPTION
## 📖 Description

We had a check to make sure an argument was passed to the `boilerplate-setup.sh` script, but it was still possible to enter an invalid value (if you didn’t know it needed to be a PascalCase term).

What would happen if you ran `./boilerplate-setup.sh foo` instead of `./boilerplate-setup.sh Foo`? The `mix.exs` would be like this:

```elixir
defmodule foo.Mixfile do
  use Mix.Project
…
```

And obviously it couldn’t compile. So now we make sure the first character is an uppercase letter.

## 📝 Notes

We don’t actually make sure it’s a _valid Elixir module term_ but I think it’s good enough for now.