### PR TITLE
Improve split routers: Health, GraphQL and Web

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -18,7 +18,7 @@ FORCE_SSL=false
 PORT=4000
 SECRET_KEY_BASE= # Generate secret with `mix phx.gen.secret`
 SESSION_KEY=elixir_boilerplate
-SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
+SESSION_SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
 
 # Database configuration
 # - Use `postgres://localhost/elixir_boilerplate_dev` if you have a local PostgreSQL server

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -51,14 +51,16 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),
   http: [port: port],
   secret_key_base: Environment.get("SECRET_KEY_BASE"),
-  session_key: Environment.get("SESSION_KEY"),
-  signing_salt: Environment.get("SIGNING_SALT"),
   static_url: [
     scheme: Environment.get("STATIC_URL_SCHEME"),
     host: Environment.get("STATIC_URL_HOST"),
     port: Environment.get("STATIC_URL_PORT")
   ],
   url: [scheme: scheme, host: host, port: port]
+
+config :elixir_boilerplate, ElixirBoilerplateWeb.Router,
+  session_key: Environment.get("SESSION_KEY"),
+  session_signing_salt: Environment.get("SESSION_SIGNING_SALT")
 
 config :elixir_boilerplate, Corsica, origins: Environment.get_list_or_first_value("CORS_ALLOWED_ORIGINS")
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,8 +21,6 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   http: [port: 4001],
   server: false,
   secret_key_base: "G0ieeRljoXGzSDPRrYc2q4ADyNHCwxNOkw7YpPNMa+JgP9iGgJKT4K96Bw/Mf/pd",
-  session_key: "test",
-  signing_salt: "qh+vmMHsOqcjKF3TSSIsghwt2go48m2+IQ+kMTOB3BrSysSr7D4a21uAtt4yp4wn",
   static_url: [
     scheme: "https",
     host: "example.com",
@@ -33,6 +31,10 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
     host: "example.",
     port: "443"
   ]
+
+config :elixir_boilerplate, ElixirBoilerplateWeb.Router,
+  session_key: "test",
+  session_signing_salt: "qh+vmMHsOqcjKF3TSSIsghwt2go48m2+IQ+kMTOB3BrSysSr7D4a21uAtt4yp4wn"
 
 config :logger, level: :warn
 

--- a/lib/elixir_boilerplate/repo.ex
+++ b/lib/elixir_boilerplate/repo.ex
@@ -8,6 +8,6 @@ defmodule ElixirBoilerplate.Repo do
   DATABASE_URL environment variable.
   """
   def init(_, opts) do
-    {:ok, Keyword.put(opts, :url, Application.get_env(:elixir_boilerplate, ElixirBoilerplate.Repo)[:url])}
+    {:ok, Keyword.put(opts, :url, Application.get_env(:elixir_boilerplate, __MODULE__)[:url])}
   end
 end

--- a/lib/elixir_boilerplate_graphql/router.ex
+++ b/lib/elixir_boilerplate_graphql/router.ex
@@ -1,27 +1,29 @@
 defmodule ElixirBoilerplateGraphQL.Router do
   use Plug.Router
-  use NewRelic.Transaction
 
-  @absinthe_configuration [
-    document_providers: {ElixirBoilerplateGraphQL, :document_providers},
-    json_codec: Jason,
-    schema: ElixirBoilerplateGraphQL.Schema
-  ]
+  defmodule GraphQL do
+    use Plug.Router
+    use NewRelic.Transaction
+
+    plug(:match)
+    plug(:dispatch)
+
+    forward("/",
+      to: Absinthe.Plug,
+      init_opts: [
+        document_providers: {ElixirBoilerplateGraphQL, :document_providers},
+        json_codec: Jason,
+        schema: ElixirBoilerplateGraphQL.Schema
+      ]
+    )
+  end
 
   plug(ElixirBoilerplateGraphQL.Plugs.Context)
 
   plug(:match)
   plug(:dispatch)
 
-  forward("/graphql",
-    to: Absinthe.Plug,
-    init_opts: @absinthe_configuration
-  )
-
-  forward("/graphiql",
-    to: Absinthe.Plug.GraphiQL,
-    init_opts: [interface: :playground] ++ @absinthe_configuration
-  )
+  forward("/graphql", to: GraphQL)
 
   match(_, do: conn)
 end

--- a/lib/elixir_boilerplate_health/router.ex
+++ b/lib/elixir_boilerplate_health/router.ex
@@ -1,0 +1,31 @@
+defmodule ElixirBoilerplateHealth.Router do
+  use Plug.Router
+
+  defmodule Health do
+    use Plug.Router
+    use NewRelic.Transaction
+
+    plug(:match)
+    plug(:dispatch)
+
+    forward(
+      "/",
+      to: PlugCheckup,
+      init_opts:
+        PlugCheckup.Options.new(
+          json_encoder: Jason,
+          checks: ElixirBoilerplateHealth.checks(),
+          error_code: ElixirBoilerplateHealth.error_code(),
+          timeout: :timer.seconds(5),
+          pretty: false
+        )
+    )
+  end
+
+  plug(:match)
+  plug(:dispatch)
+
+  forward("/health", to: Health)
+
+  match(_, do: conn)
+end


### PR DESCRIPTION
## 📖 Description

We already have two routers, GraphQL and Web. But the way they were setup, we would always have this line in the server logs:

```
[warn] You have instrumented twice in the same plug! Please `use NewRelic.Transaction` only once.
```

It was because of this line in `ElixirBoilerplateGraphQL.Router`:

```elixir
use NewRelic.Transaction
```

Even if the request was not sent to `/graphql`, the New Relic instrumentation was initialized for the request and _then again_ in `ElixirBoilerplateWeb.Router`’s `browser` pipeline.

I wanted to improve that and make sure we initialize New Relic instrumentation only when we need it.

## 📝 Notes

So now we have three routers that behave pretty much the same:

* `ElixirBoilerplateHealth.Router`
* `ElixirBoilerplateGraphQL.Router`
* `ElixirBoilerplateWeb.Router`

The three of them only evaluate New Relic plugs when requests are made respectively to `/health`, `/graphql` or `/*`.

### Before

Previously, a router (like `ElixirBoilerplateGraphQL.Router`) was set up like this:

```elixir
def Foo do
  use NewRelic.Transaction
  forward("/graphql", to: Absinthe.Plug)
end
```

New Relic is involved in _every request_, not just if `/graphql` is requested.

### After

Now, the same router is set up like this:

```elixir
def Foo do
  defmodule Bar do
    use NewRelic.Transaction
    forward("/", to: Absinthe.Plug)
  end

  forward("/graphql", to: Bar)
end
```

So now New Relic is only involved if `/graphql` is specifically requested (and we’re inside `Bar`.

## 🎉 Extra notes

* I moved the `session` plug to the last router (Web), since it’s useless to evaluate it for health and GraphQL endpoints. I also renamed `SIGNING_SALT` to `SESSION_SIGNING_SALT` since it’s only used to sign session data
* I removed the `/graphiql` endpoint. It was causing too much code duplication just to be able to create a new endpoint with `[interface: :playground]` as extra options. Maybe the API shouldn’t provide this kind of development tools? Since we can just use any instance of GraphiQL (eg. a desktop GraphiQL.app) and connect to the public API URL?
* I added the missing `Application.get_env(:app, __MODULE__)` pattern in a few places (where `Application.get_env(:app, The.Whole.Module.Name)` pattern was used)