### PR TITLE
Do not provide `static_url` configuration to Phoenix endpoint if `STATIC_URL_HOST` isn’t present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Since it is a boilerplate project, there are technically no official (versioned)
 
 ## 2020-05-27
 
-- Do not provide `static_url` configuration to Phoenix endpoint if `STATIC_URL_HOST` isn’t present (#)
+- Do not provide `static_url` configuration to Phoenix endpoint if `STATIC_URL_HOST` isn’t present (#110)
 
 ## 2020-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2020-05-27
+
+- Do not provide `static_url` configuration to Phoenix endpoint if `STATIC_URL_HOST` isn’t present (#)
+
 ## 2020-05-15
 
 - Do not raise “missing `_test` suffix” error when DATABASE_URL is not present

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -31,6 +31,17 @@ defmodule Environment do
       _ -> nil
     end
   end
+
+  def get_static_url_config(nil), do: nil
+  def get_static_url_config(""), do: nil
+
+  def get_static_url_config(host) do
+    [
+      host: host,
+      scheme: Environment.get("STATIC_URL_SCHEME"),
+      port: Environment.get("STATIC_URL_PORT")
+    ]
+  end
 end
 
 force_ssl = Environment.get_boolean("FORCE_SSL")
@@ -51,12 +62,8 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),
   http: [port: port],
   secret_key_base: Environment.get("SECRET_KEY_BASE"),
-  static_url: [
-    scheme: Environment.get("STATIC_URL_SCHEME"),
-    host: Environment.get("STATIC_URL_HOST"),
-    port: Environment.get("STATIC_URL_PORT")
-  ],
-  url: [scheme: scheme, host: host, port: port]
+  static_url: get_static_url_config(Environment.get("STATIC_URL_HOST")),
+  url: [host: host, scheme: scheme, port: port]
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Router,
   session_key: Environment.get("SESSION_KEY"),

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -32,10 +32,10 @@ defmodule Environment do
     end
   end
 
-  def get_static_url_config(nil), do: nil
-  def get_static_url_config(""), do: nil
+  def get_endpoint_static_url_config(nil), do: nil
+  def get_endpoint_static_url_config(""), do: nil
 
-  def get_static_url_config(host) do
+  def get_endpoint_static_url_config(host) do
     [
       host: host,
       scheme: Environment.get("STATIC_URL_SCHEME"),
@@ -62,7 +62,7 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),
   http: [port: port],
   secret_key_base: Environment.get("SECRET_KEY_BASE"),
-  static_url: get_static_url_config(Environment.get("STATIC_URL_HOST")),
+  static_url: get_endpoint_static_url_config(Environment.get("STATIC_URL_HOST")),
   url: [host: host, scheme: scheme, port: port]
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Router,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -62,7 +62,7 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),
   http: [port: port],
   secret_key_base: Environment.get("SECRET_KEY_BASE"),
-  static_url: get_endpoint_static_url_config(Environment.get("STATIC_URL_HOST")),
+  static_url: Environment.get_endpoint_static_url_config(Environment.get("STATIC_URL_HOST")),
   url: [host: host, scheme: scheme, port: port]
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Router,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -38,8 +38,8 @@ defmodule Environment do
   def get_endpoint_static_url_config(host) do
     [
       host: host,
-      scheme: Environment.get("STATIC_URL_SCHEME"),
-      port: Environment.get("STATIC_URL_PORT")
+      scheme: get("STATIC_URL_SCHEME"),
+      port: get("STATIC_URL_PORT")
     ]
   end
 end


### PR DESCRIPTION
## 📖 Description

Like I explained in #109, we don’t want to provide a `static_url` configuration to the endpoint if at least `STATIC_URL_HOST` isn’t present. By providing `nil` instead, this will allow the proper fallback to work (which uses the endpoint’s `url` configuration).

## 📝 Notes

Hat tip to @gingman for finding the bug and helping me _rubber-duck-debugging_ it 😁 

## 📓 References

This closes #109 
