### PR TITLE
Use GitHub Actions cache v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: 12.15
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: deps-cache
         with:
           path: deps
@@ -43,13 +43,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deps-
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: build-cache
         with:
           path: _build
           key: ${{ runner.os }}-build-${{ matrix.otp-version }}-${{ matrix.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: npm-cache
         with:
           path: ~/.npm


### PR DESCRIPTION
## 📖 Description

GitHub released a new version of their `cache` action which is supposed to bring increased performance and improved cache sizes.