### PR TITLE
Use String.ends_with?/2 to catch non-test database URL when running tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -9,10 +9,10 @@ defmodule TestEnvironment do
   def get_database_url do
     url = Environment.get("DATABASE_URL")
 
-    if is_nil(url) || String.contains?(url, @database_name_suffix) do
+    if is_nil(url) || String.ends_with?(url, @database_name_suffix) do
       url
     else
-      raise "Expected database URL to ends with '#{@database_name_suffix}', got: #{url}"
+      raise "Expected database URL to end with '#{@database_name_suffix}', got: #{url}"
     end
   end
 end


### PR DESCRIPTION
## 📖 Description

The error message for the non-test database URL check says that the URL should end with `_test`. Therefore we should use `String.ends_with?/2` instead of `String.contains?/2`.

I also fixed a typo in the message 🤓 