### PR TITLE
drop ineffectual flag from Makefile check-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ check-code-security:
 
 .PHONY: check-format
 check-format:
-	mix format --dry-run --check-formatted
+	mix format --check-formatted
 	cd assets && npx prettier --check $(PRETTIER_FILES_PATTERN)
 
 .PHONY: check-unused-dependencies


### PR DESCRIPTION
## 📖 Description

Drop ineffectual flag from Makefile `check-format`.

## 📝 Notes

The use of `--dry-run` combined with `--check-formatted` is ineffective and I would suggest using simply `mix format --check-formatted`.

## 📓 References

https://github.com/elixir-lang/elixir/blob/v1.10.4/lib/mix/lib/mix/tasks/format.ex#L428