### PR TITLE
Fix Basic Auth support following change from basic_auth lib to Plug.BasicAuth

### DIFF
--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -108,7 +108,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
     basic_auth_config = Application.get_env(:elixir_boilerplate, :basic_auth)
 
     if basic_auth_config[:username] do
-      Plug.BasicAuth.call(conn, basic_auth_config)
+      Plug.BasicAuth.basic_auth(conn, basic_auth_config)
     else
       conn
     end


### PR DESCRIPTION
## 📖 Description

During integration in another project, I noticed that the Plug.BasicAuth was calling an undefined method and tests were failing. So, this actually fix it and it now Basic Auth work as expected when values are provided.

```bash
warning: Plug.BasicAuth.call/2 is undefined or private lib/elixir_boilerplate_web/endpoint.ex:111: ElixirBoilerplateWeb.Endpoint.basic_auth/2
```

```bash
  1) test GET / (ElixirBoilerplateWeb.Home.ControllerTest)
     test/elixir_boilerplate_web/home/controller_test.exs:4
     ** (UndefinedFunctionError) function Plug.BasicAuth.call/2 is undefined or private
     code: conn = get(conn, "/")
```

## 📝 Notes

Not sure why the tests were not failing on the #119, any idea?
