### PR TITLE
Fix warnings with Faker and Phoenix.ConnTest

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -88,7 +88,7 @@ defmodule ElixirBoilerplate.Mixfile do
 
       # Test factories
       {:ex_machina, "~> 2.4", only: :test},
-      {:faker, "~> 0.12", only: :test},
+      {:faker, "~> 0.15", only: :test},
 
       # Test coverage
       {:excoveralls, "~> 0.13", only: :test}

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,7 +23,9 @@ defmodule ElixirBoilerplateWeb.ConnCase do
   using do
     quote do
       # Import conveniences for testing with connections
-      use Phoenix.ConnTest
+      import Plug.Conn
+      import Phoenix.ConnTest
+
       import ElixirBoilerplateWeb.Router.Helpers
 
       # The default endpoint for testing

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,6 +3,6 @@ defmodule ElixirBoilerplate.Factory do
 
   # This is a sample factory to make sure our setup is working correctly.
   def name_factory(_) do
-    Faker.Name.name()
+    Faker.Person.name()
   end
 end


### PR DESCRIPTION
## 📖 Description

Fix deprecation warnings coming from Faker and the latest Phoenix upgrade as seen below:

```
warning: Using Phoenix.ConnTest is deprecated, instead of:

    use Phoenix.ConnTest

do:

    import Plug.Conn
    import Phoenix.ConnTest

  test/elixir_boilerplate_web/ping_test.exs:2: ElixirBoilerplateWeb.PingTest (module)
```

```
warning: Faker.Name.name/0 is deprecated. Use Faker.Person.name/0 instead.
  test/support/factory.ex:6: ElixirBoilerplate.Factory.name_factory/1
```