### PR TITLE
Fix the missing pieces for the Sentry 8.0 and Phoenix 1.5 upgrades

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10219,12 +10219,12 @@
       }
     },
     "phoenix": {
-      "version": "github:phoenixframework/phoenix#b0278829076e30deb994b83bd246966476a9d0b4",
-      "from": "github:phoenixframework/phoenix#v1.4.12"
+      "version": "github:phoenixframework/phoenix#3a5e5c5abf7841700d6ed88c9147f82a55ec2d59",
+      "from": "github:phoenixframework/phoenix#v1.5.5"
     },
     "phoenix_html": {
-      "version": "github:phoenixframework/phoenix_html#e0970ce6f06e61fe9f56bca63c4adc83f7369ef1",
-      "from": "github:phoenixframework/phoenix_html#v2.13.3"
+      "version": "github:phoenixframework/phoenix_html#bb94c019beff75b1908ac33b1d1699fce366bed8",
+      "from": "github:phoenixframework/phoenix_html#v2.14.2"
     },
     "pify": {
       "version": "2.3.0",

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,9 @@ defmodule ElixirBoilerplate.Mixfile do
 
   defp deps do
     [
+      # HTTP Client
+      {:hackney, "~> 1.16"},
+
       # HTTP server
       {:plug_cowboy, "~> 2.3"},
       {:plug_canonical_host, "~> 2.0"},


### PR DESCRIPTION
## 📖 Description

Add the missing pieces from the latest upgrades of libs!

For Sentry, due to the way they expect an HTTP Client by default, they were fall backing to `Hackney`, which is documented here in their 8.0 upgrade documentation: https://gist.github.com/mitchellhenke/dce120a5515565076b13962ee0be749b

Instead of implementing our own behavior corresponding to their expectations, let's define `Hackney` as our go to HTTP Client lib.

This avoid the following start error:

```
** (Mix) Could not start application sentry: exited in: Sentry.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (RuntimeError) cannot start Sentry.HackneyClient because :hackney is not available.
Please make sure to add hackney as a dependency:
    {:hackney, "~> 1.8"}
            (sentry 8.0.2) lib/sentry/http_client.ex:26: Sentry.HackneyClient.child_spec/0
            (sentry 8.0.2) lib/sentry.ex:101: Sentry.start/2
            (kernel 7.1) application_master.erl:277: :application_master.start_it_old/4
```