### PR TITLE
Store Plug.SSL plug in endpoint module attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2020-11-04
+
+- Move `Plug.SSL` plug initialization to endpoint module attribute (#130)
+
 ## 2020-10-08
 
 - Upgrage to Erlang `23.1.1` and Alpine `1.12.0`

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -4,6 +4,8 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
   alias Plug.Conn
 
+  @plug_ssl Plug.SSL.init(rewrite_on: [:x_forwarded_proto])
+
   socket("/socket", ElixirBoilerplateWeb.Socket)
 
   plug(:ping)
@@ -91,9 +93,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
   defp force_ssl(conn, _opts) do
     if Application.get_env(:elixir_boilerplate, :force_ssl) do
-      opts = Plug.SSL.init(rewrite_on: [:x_forwarded_proto])
-
-      Plug.SSL.call(conn, opts)
+      Plug.SSL.call(conn, @plug_ssl)
     else
       conn
     end


### PR DESCRIPTION
## 📖 Description

Inspired by this [blog post](https://dashbit.co/blog/how-we-verify-webhooks) by Dashbit, I took the `Plug.SSL.init` call and moved it to a module attribute since it doesn’t depend on any runtime environment variables.