### PR TITLE
Simplification of the Router URLs configuration

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -11,11 +11,9 @@
 # -----------------------------------------------------------------------------
 
 # Server configuration
-CANONICAL_HOST=localhost
+CANONICAL_URL=http://localhost:4000
 CORS_ALLOWED_ORIGINS=*
 DEBUG_ERRORS=true
-FORCE_SSL=false
-PORT=4000
 SECRET_KEY_BASE= # Generate secret with `mix phx.gen.secret`
 SESSION_KEY=elixir_boilerplate
 SESSION_SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
@@ -35,9 +33,7 @@ DATABASE_POOL_SIZE=20
 # CSS and JavaScript). We often use these variables to configure a CDN that
 # will cache static files once they have been served by the Phoenix
 # application.
-# STATIC_URL_SCHEME=
-# STATIC_URL_HOST=
-# STATIC_URL_PORT=
+# STATIC_URL=
 
 # New Relic configuration
 # NEW_RELIC_APP_NAME=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2020-11-12
+
+Simplification of the Router URLs configuration.
+
+Router's Endpoint config now requires only a CANONICAL_URL and a STATIC_URL from which it extrapolates the different URI components such as `scheme`, `host` and `port`.
+
+Environment variables changes:
+
+_Added_
+
+- `CANONICAL_URL=`
+- `STATIC_URL=`
+
+_Removed_
+
+- `PORT=`
+- `FORCE_SSL=`
+- `STATIC_URL_SCHEME=`
+- `STATIC_URL_HOST=`
+- `STATIC_URL_PORT=`
+
 ## 2020-11-04
 
 - Move `Plug.SSL` plug initialization to endpoint module attribute (#130)


### PR DESCRIPTION
## 📖 Description

Simplification of the Router URLs configuration by reducing the environment variables required to boot up the server! The idea is to reuse through `URI.parse()` the different components instead of asking them separately. 

This change also fixes an issue where the `PORT` was used for the URL when using the Routers generated methods such as `ElixirBoilerplateWeb.Router.Helpers.home_url(ElixirBoilerplateWeb.Endpoint, :index)`. 