### PR TITLE
Revert removal of `PORT` environment variable

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -11,7 +11,7 @@
 # -----------------------------------------------------------------------------
 
 # Server configuration
-CANONICAL_URL=http://localhost:4000
+PORT=4000
 CORS_ALLOWED_ORIGINS=*
 DEBUG_ERRORS=true
 SECRET_KEY_BASE= # Generate secret with `mix phx.gen.secret`
@@ -24,6 +24,12 @@ SESSION_SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
 # - Use `postgres://postgres:development@localhost/elixir_boilerplate_dev` if you’re using the PostgreSQL server provided by Docker Compose
 DATABASE_URL=postgres://localhost/elixir_boilerplate_dev
 DATABASE_POOL_SIZE=20
+
+# URL configuration (used by Phoenix to build URLs from routes)
+# Other features also extracts values from this URL:
+# - Redirect to canonical host
+# - Force SSL requests
+CANONICAL_URL=http://localhost:4000
 
 # Basic Authentication
 # BASIC_AUTH_USERNAME=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2020-11-13
+
+- Revert the removal of `PORT` environment variable (#133)
+
 ## 2020-11-12
 
-Simplification of the Router URLs configuration.
+Simplification of the Router URLs configuration (#132)
 
 Router's Endpoint config now requires only a CANONICAL_URL and a STATIC_URL from which it extrapolates the different URI components such as `scheme`, `host` and `port`.
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -67,7 +67,7 @@ config :elixir_boilerplate, ElixirBoilerplate.Repo,
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   debug_errors: Environment.get_boolean("DEBUG_ERRORS"),
-  http: [port: Environment.get_uri_part(canonical_uri, :port)],
+  http: [port: Environment.get("PORT")],
   secret_key_base: Environment.get("SECRET_KEY_BASE"),
   static_url: Environment.get_endpoint_url_config(static_uri),
   url: Environment.get_endpoint_url_config(canonical_uri)


### PR DESCRIPTION
## 📖 Description

#132 removed the use of `PORT` in favor of extracting the port from `CANONICAL_URL`.

We still need an explicit `PORT` variable to be able to specify a local port the server will run on vs. the port that will be used to generate URLs.

## 📝 Notes

I also improved the documentation for `CANONICAL_URL` in `.env.dev` to make it clear what’s it’s used for 💪 