### PR TITLE
Use the new GitHub action repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,12 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           elixir-version: ${{ matrix.elixir-version }}
           otp-version: ${{ matrix.otp-version }}
 
-      - uses: erlef/setup-elixir@v1
+      - uses: actions/setup-node@v1
         with:
           node-version: 14.15
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           elixir-version: ${{ matrix.elixir-version }}
           otp-version: ${{ matrix.otp-version }}
 
-      - uses: actions/setup-node@v1
+      - uses: erlef/setup-elixir@v1
         with:
           node-version: 14.15
 


### PR DESCRIPTION
## 📖 Description

Le repo original (https://github.com/actions/setup-elixir) est deprecated en faveur de https://github.com/erlef/setup-elixir. On change donc le nom du repo dans la définition du GitHub Actions pour s'assurer d'utiliser le bon.

## 🦀 Dispatch

- `#dispatch/elixir`
