### PR TITLE
Add StrictModuleLayout Credo readability check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -28,6 +28,7 @@
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},
         {Credo.Check.Readability.SinglePipe},
+        {Credo.Check.Readability.StrictModuleLayout},
         {Credo.Check.Readability.TrailingBlankLine},
         {Credo.Check.Readability.TrailingWhiteSpace},
         {Credo.Check.Readability.VariableNames},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2021-03-10
+
+- Add `Credo.Check.Readability.StrictModuleLayout` readability check
+
 ## 2020-11-25
 
 - Upgrage to Elixir `1.11` and NodeJS `14.15`

--- a/lib/elixir_boilerplate/release_tasks.ex
+++ b/lib/elixir_boilerplate/release_tasks.ex
@@ -1,7 +1,7 @@
 defmodule ElixirBoilerplate.ReleaseTasks do
-  @app :elixir_boilerplate
-
   alias Ecto.Migrator
+
+  @app :elixir_boilerplate
 
   def migrate do
     IO.puts("Running migrations for #{@app}")


### PR DESCRIPTION
## 📖 Description

This pull request adds the [`Credo.Check.Readability.StrictModuleLayout`](https://github.com/rrrene/credo/blob/master/lib/credo/check/readability/strict_module_layout.ex) check to our Credo configuration.

This will ensure all of our modules are consistently structured in the project and also in all of our Elixir projects.

## 📝 Notes

Fun fact : I ran the check in one of our project (962 analyzed source files) and the check only raised 11 issues (that are also pretty easy to fix).

## 🦀 Dispatch

- `#dispatch/elixir`