### PR TITLE
Generate and expose JS source maps by default

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -11,7 +11,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 module.exports = (_env, _options) => ({
   optimization: {
     minimizer: [
-      new TerserPlugin({cache: true, parallel: true, sourceMap: false}),
+      new TerserPlugin({cache: true, parallel: true}),
       new OptimizeCSSAssetsPlugin({})
     ]
   },
@@ -40,5 +40,6 @@ module.exports = (_env, _options) => ({
   plugins: [
     new MiniCssExtractPlugin({filename: '../css/app.css'}),
     new CopyWebpackPlugin({patterns: [{from: 'static/', to: '../'}]})
-  ]
+  ],
+  devtool: 'source-map'
 });

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -9,7 +9,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const devtoolOption = (mode) => {
-  if (mode == 'production') return 'source-map';
+  if (mode === 'production') return 'source-map';
   return 'eval';
 };
 

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -8,7 +8,12 @@ const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = (_env, _options) => ({
+const buildDevtoolOption = (mode) => {
+  if (mode == 'production') return 'source-map';
+  return 'eval';
+};
+
+module.exports = (_, {mode}) => ({
   optimization: {
     minimizer: [
       new TerserPlugin({cache: true, parallel: true}),
@@ -41,5 +46,5 @@ module.exports = (_env, _options) => ({
     new MiniCssExtractPlugin({filename: '../css/app.css'}),
     new CopyWebpackPlugin({patterns: [{from: 'static/', to: '../'}]})
   ],
-  devtool: 'source-map'
+  devtool: buildDevtoolOption(mode)
 });

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -8,7 +8,7 @@ const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-const buildDevtoolOption = (mode) => {
+const devtoolOption = (mode) => {
   if (mode == 'production') return 'source-map';
   return 'eval';
 };
@@ -46,5 +46,5 @@ module.exports = (_, {mode}) => ({
     new MiniCssExtractPlugin({filename: '../css/app.css'}),
     new CopyWebpackPlugin({patterns: [{from: 'static/', to: '../'}]})
   ],
-  devtool: buildDevtoolOption(mode)
+  devtool: devtoolOption(mode)
 });

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -22,7 +22,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
     at: "/",
     from: :elixir_boilerplate,
     gzip: false,
-    only: ~w(css fonts images js map favicon.ico robots.txt)
+    only: ~w(css fonts images js favicon.ico robots.txt)
   )
 
   # Code reloading can be explicitly enabled under the

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -22,7 +22,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
     at: "/",
     from: :elixir_boilerplate,
     gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    only: ~w(css fonts images js map favicon.ico robots.txt)
   )
 
   # Code reloading can be explicitly enabled under the


### PR DESCRIPTION
## 📖 Description

We should generate and expose our JavaScript and CSS source maps by default.

## 📝 Notes

All [possible values](https://webpack.js.org/configuration/devtool/#devtool) are documented on Webpack website. I used the recommended values for both development and production builds.

## 🦀 Dispatch

We don’t have a `#dispatch/webpack` stack but I’ll mention @Madumo manually here 👋
