### PR TITLE
Use gzip to serve assets if possible

### DIFF
--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -21,7 +21,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
   plug(Plug.Static,
     at: "/",
     from: :elixir_boilerplate,
-    gzip: false,
+    gzip: true,
     only: ~w(css fonts images js favicon.ico robots.txt)
   )
 


### PR DESCRIPTION
## 📖 Description

`Plug.Static` supports a `gzip` option that, if enabled, will force it to use the `<path>.gz` file to serve requests to `<path>` if the request’s `accept-encoding` header is compatible with gzip.

And as the `mix phx.digest` task generates those `.gz` files, we should take advantage of this feature 🤓

## 🦀 Dispatch

- `#dispatch/elixir`
