### PR TITLE
Decrease `npm ci` output volume in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk update --no-cache && \
 
 # Install JS dependencies
 COPY assets assets
-RUN npm ci --prefix assets --no-audit --no-color --unsafe-perm
+RUN npm ci --prefix assets --no-audit --no-color --unsafe-perm --progress=false --loglevel=error
 
 # Build JS/CSS assets
 RUN npm run --prefix assets deploy


### PR DESCRIPTION
## 📖 Description

This pull requests adds the `--progress=false --loglevel=error` flags to the `npm ci` command ran in the Docker build, to avoid outputting useless data.

## 🦀 Dispatch

- `#dispatch/devops`
