### PR TITLE
Make test suite fail on compiler warning

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
+# NOTE: When using Elixir 1.12+, we could ditch the next line and use `mix test --warnings-as-errors` instead
 Code.put_compiler_option(:warnings_as_errors, true)
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
+Code.put_compiler_option(:warnings_as_errors, true)
+
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 
 ExUnit.start()


### PR DESCRIPTION
## 📖 Description

We want the test suite to fail if there are compiler warning in test files (since they won’t be picked up by `mix compile --warning-as-errors`).

Elixir 1.12 introduces `mix test --warning-as-errors` but we have to use `Code.put_compiler_option` for now to keep supporting Elixir 1.11.

## 📓 References

[Warnings as errors and tests](https://dashbit.co/blog/tests-with-warnings-as-errors) on Dashbit blog

## 🦀 Dispatch

- `#dispatch/elixir`
