### PR TITLE
Fix Dockerfile after latests deps updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ ENV APP_NAME=${APP_NAME} \
 # Install Alpine dependencies
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
-    apk add --no-cache bash openssl
+    apk add --no-cache bash openssl libgcc libstdc++ ncurses-libs
 
 WORKDIR /opt/elixir_boilerplate
 


### PR DESCRIPTION
## 📖 Description

The Docker image crash on startup with the following error:

```
Error loading shared library libstdc++.so.6: No such file or directory (needed by /app/erts-12.0.2/bin/beam.smp)
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /app/erts-12.0.2/bin/beam.smp)
...
```

Installing the missing runtime dependencies seems to resolve this issues.

## 📓 References

https://elixirforum.com/t/docker-run-error-loading-shared-library-libstdc-so-6-and-libgcc-s-so-1/40496

## 🦀 Dispatch

- `#dispatch/elixir`
