### PR TITLE
Convert CI workflow to “Reusable CI”

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -19,7 +19,7 @@ SESSION_SIGNING_SALT=qh+vmMHsOqcjKF3TSSIsghwt2go48m2+IQ+kMTOB3BrSysSr7D4a21uAtt4
 # - Use `postgres://localhost/elixir_boilerplate_test` if you have a local PostgreSQL server
 # - Use `postgres://username:password@localhost/elixir_boilerplate_test` if you have a local PostgreSQL server with credentials
 # - Use `postgres://postgres:development@localhost/elixir_boilerplate_test` if you’re using the PostgreSQL server provided by Docker Compose
-DATABASE_URL=postgres://postgres:boilerplate@localhost/elixir_boilerplate_test
+DATABASE_URL=postgres://postgres:password@localhost/database_test
 
 # URL configuration (used by Phoenix to build URLs from routes)
 # Other features also extracts values from this URL:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,5 +13,6 @@ jobs:
   ci:
     uses: mirego/elixir-boilerplate/.github/workflows/reusable-ci.yaml@feature/convert-ci-to-reusable-ci
     with:
-      otp-version: [24.1.2]
-      elixir-version: [1.12.3]
+      otp-version: 24.1.2
+      elixir-version: 1.12.3
+      database-image: postgres:12

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,3 +12,6 @@ on:
 jobs:
   ci:
     uses: mirego/elixir-boilerplate/.github/workflows/reusable-ci.yaml@feature/convert-ci-to-reusable-ci
+    with:
+      otp-version: [24.1.2]
+      elixir-version: [1.12.3]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,72 +4,11 @@ on:
   push:
     branches:
       - master
+      - feature/convert-ci-to-reusable-ci
   pull_request:
     branches:
       - "**"
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otp-version: [24.1.2]
-        elixir-version: [1.12.3]
-
-    services:
-      db:
-        image: postgres:12
-        env:
-          POSTGRES_DB: elixir_boilerplate_test
-          POSTGRES_PASSWORD: boilerplate
-        ports: ["5432:5432"]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-    env:
-      MIX_ENV: test
-      DATABASE_URL: postgres://postgres:boilerplate@localhost/elixir_boilerplate_test
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: erlef/setup-elixir@v1
-        with:
-          elixir-version: ${{ matrix.elixir-version }}
-          otp-version: ${{ matrix.otp-version }}
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14.18
-
-      - uses: actions/cache@v2
-        id: deps-cache
-        with:
-          path: deps
-          key: ${{ runner.os }}-deps-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
-          restore-keys: |
-            ${{ runner.os }}-deps-
-
-      - uses: actions/cache@v2
-        id: build-cache
-        with:
-          path: _build
-          key: ${{ runner.os }}-build-${{ matrix.otp-version }}-${{ matrix.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
-
-      - uses: actions/cache@v2
-        id: npm-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles(format('{0}/assets/package-lock.json', github.workspace)) }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-
-      - name: Setup environment variables
-        uses: c-py/action-dotenv-to-setenv@v2
-        with:
-          env-file: .env.test
-
-      - run: make prepare
-      - run: make check
-      - run: make lint
-      - run: make test
-      - run: make build DOCKER_IMAGE_TAG=latest
+    uses: mirego/elixir-boilerplate/.github/workflows/reusable-ci.yaml@feature/convert-ci-to-reusable-ci

--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -3,40 +3,39 @@ name: Reusable CI
 on:
   workflow_call:
     inputs:
-      otp-version:
+      database-image:
         required: true
         type: string
       elixir-version:
         required: true
         type: string
+      otp-version:
+        required: true
+        type: string
 jobs:
   reusable-ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otp-version: ${{ inputs.otp-version }}
-        elixir-version: ${{ inputs.elixir-version }}
 
     services:
       db:
-        image: postgres:12
+        image: ${{ inputs.database-image }}
         env:
-          POSTGRES_DB: elixir_boilerplate_test
-          POSTGRES_PASSWORD: boilerplate
+          POSTGRES_DB: database_test
+          POSTGRES_PASSWORD: password
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     env:
       MIX_ENV: test
-      DATABASE_URL: postgres://postgres:boilerplate@localhost/elixir_boilerplate_test
+      DATABASE_URL: postgres://postgres:password@localhost/database_test
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: erlef/setup-elixir@v1
         with:
-          elixir-version: ${{ matrix.elixir-version }}
-          otp-version: ${{ matrix.otp-version }}
+          elixir-version: ${{ inputs.elixir-version }}
+          otp-version: ${{ inputs.otp-version }}
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -27,7 +27,6 @@ jobs:
 
     env:
       MIX_ENV: test
-      DATABASE_URL: postgres://postgres:password@localhost/database_test
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -1,0 +1,70 @@
+name: Reusable CI
+
+on:
+  workflow_call:
+
+jobs:
+  reusable-ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp-version: [24.1.2]
+        elixir-version: [1.12.3]
+
+    services:
+      db:
+        image: postgres:12
+        env:
+          POSTGRES_DB: elixir_boilerplate_test
+          POSTGRES_PASSWORD: boilerplate
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    env:
+      MIX_ENV: test
+      DATABASE_URL: postgres://postgres:boilerplate@localhost/elixir_boilerplate_test
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: erlef/setup-elixir@v1
+        with:
+          elixir-version: ${{ matrix.elixir-version }}
+          otp-version: ${{ matrix.otp-version }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.18
+
+      - uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: deps
+          key: ${{ runner.os }}-deps-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
+      - uses: actions/cache@v2
+        id: build-cache
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ matrix.otp-version }}-${{ matrix.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
+
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles(format('{0}/assets/package-lock.json', github.workspace)) }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Setup environment variables
+        uses: c-py/action-dotenv-to-setenv@v2
+        with:
+          env-file: .env.test
+
+      - run: make prepare
+      - run: make check
+      - run: make lint
+      - run: make test
+      - run: make build DOCKER_IMAGE_TAG=latest

--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -2,14 +2,20 @@ name: Reusable CI
 
 on:
   workflow_call:
-
+    inputs:
+      otp-version:
+        required: true
+        type: string
+      elixir-version:
+        required: true
+        type: string
 jobs:
   reusable-ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp-version: [24.1.2]
-        elixir-version: [1.12.3]
+        otp-version: ${{ inputs.otp-version }}
+        elixir-version: ${{ inputs.elixir-version }}
 
     services:
       db:

--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -119,6 +119,10 @@ header "Removing boilerplate code of conduct and contribution information → ht
 run rm -fr CODE_OF_CONDUCT.md CONTRIBUTING.md
 success "Done!\n"
 
+header "Removing reusable-ci GitHub Actions workflow"
+run rm -fr .github/workflows/reusable-ci.yaml
+success "Done!\n"
+
 header "Removing boilerplate setup script"
 run rm -fr boilerplate-setup.sh
 success "Done!\n"


### PR DESCRIPTION
## 📖 Description

This pull request introduces a new GitHub Action workflow: _Reusable CI_. This make it possible for projects to use this simple CI workflow:

```yaml
name: CI

on:
  push:
    branches:
      - master
  pull_request:
    branches:
      - "**"

jobs:
  ci:
    uses: mirego/elixir-boilerplate/.github/workflows/reusable-ci.yaml@master
```

Instead of having to _duplicate_ the whole YAML file inside each project repository.

## 📝 Notes

All references to `feature/convert-ci-to-reusable-ci` will be removed before merging 🤓

## 🦀 Dispatch

- `#dispatch/elixir`
