### PR TITLE
Introduce add-translations and order-by flags to accent-sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ dependencies: ## Install dependencies
 
 .PHONY: sync-translations
 sync-translations: ## Synchronize translations with Accent
-	npx accent sync
+	npx accent sync --add-translations --order-by=key-asc
 
 .PHONY: test
 test: ## Run the test suite


### PR DESCRIPTION
## 📖 Description

I suggest adding these 2 options to our default config since they fit most of our projects better.

`--add-translations` since we generally ship bilingual (fr/en) projects for which the developers translates the newly added strings.
`--order-by=key-asc` to help having diffs that are more meaningful after doing a sync (remove all the noise caused by strings that swap places with others).

Thoughts ?

## 🦀 Dispatch

- `#dispatch/elixir`
