### PR TITLE
Synchronize docker setup with phx.new and phx.gen.release generators

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp-version: [24.2.1]
-        elixir-version: [1.13.2]
+        otp-version: [24.3]
+        elixir-version: [1.13]
 
     services:
       db:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 24.2.1
-elixir 1.13.2-otp-24
-nodejs 16.13.2
+erlang 24.3.3
+elixir 1.13.3-otp-24
+nodejs 16.14.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN npm ci --prefix assets
 #
 # Step 2 - hex dependencies
 #
-FROM hexpm/elixir:1.13.2-erlang-24.2.1-debian-bullseye-20210902-slim AS otp-builder
+FROM hexpm/elixir:1.13.3-erlang-24.3.3-debian-bullseye-20210902-slim AS otp-builder
 
 # Install Debian dependencies
 RUN apt-get update -y && \
@@ -48,7 +48,7 @@ COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
 
 # Compile assets
-COPY --from=npm-builder /app/assets assets 
+COPY --from=npm-builder /app/assets assets
 COPY priv priv
 RUN mix esbuild default
 RUN mix phx.digest

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ prepare:
 
 .PHONY: build
 build: ## Build the Docker image for the OTP release
-	docker build --build-arg APP_NAME=$(APP_NAME) --build-arg APP_VERSION=$(APP_VERSION) --rm --tag $(DOCKER_LOCAL_IMAGE) .
+	docker build --rm --tag $(DOCKER_LOCAL_IMAGE) .
 
 .PHONY: push
 push: ## Push the Docker image to the registry

--- a/lib/elixir_boilerplate/release.ex
+++ b/lib/elixir_boilerplate/release.ex
@@ -1,10 +1,10 @@
-defmodule ElixirBoilerplate.ReleaseTasks do
+defmodule ElixirBoilerplate.Release do
   alias Ecto.Migrator
 
   @app :elixir_boilerplate
 
   def migrate do
-    IO.puts("Running migrations for #{@app}")
+    load_app()
 
     for repo <- repos() do
       {:ok, _, _} = Migrator.with_repo(repo, &Migrator.run(&1, :up, all: true))
@@ -12,11 +12,16 @@ defmodule ElixirBoilerplate.ReleaseTasks do
   end
 
   def rollback(repo, version) do
+    load_app()
+
     {:ok, _, _} = Migrator.with_repo(repo, &Migrator.run(&1, :down, to: version))
   end
 
   defp repos do
-    Application.load(@app)
     Application.fetch_env!(@app, :ecto_repos)
+  end
+
+  defp load_app do
+    Application.load(@app)
   end
 end

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -32,7 +32,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
     plug(Phoenix.LiveReloader)
     plug(Phoenix.CodeReloader)
-    plug Phoenix.Ecto.CheckRepoStatus, otp_app: :elixir_boilerplate
+    plug(Phoenix.Ecto.CheckRepoStatus, otp_app: :elixir_boilerplate)
   end
 
   plug(Plug.RequestId)

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -32,6 +32,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
     plug(Phoenix.LiveReloader)
     plug(Phoenix.CodeReloader)
+    plug Phoenix.Ecto.CheckRepoStatus, otp_app: :elixir_boilerplate
   end
 
   plug(Plug.RequestId)

--- a/priv/scripts/docker-entrypoint.sh
+++ b/priv/scripts/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-# Run the migration first using the custom release task
-/opt/$APP_NAME/bin/$APP_NAME eval "ElixirBoilerplate.ReleaseTasks.migrate"
-
-# Launch the OTP release and replace the caller as Process #1 in the container
-exec /opt/$APP_NAME/bin/$APP_NAME "$@"

--- a/rel/overlays/bin/migrate
+++ b/rel/overlays/bin/migrate
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+exec ./elixir_boilerplate eval ElixirBoilerplate.Release.migrate

--- a/rel/overlays/bin/migrate
+++ b/rel/overlays/bin/migrate
@@ -1,3 +1,4 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
+
 exec ./elixir_boilerplate eval ElixirBoilerplate.Release.migrate

--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,3 +1,7 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
+
+# Always run migrations
+./elixir_boilerplate eval ElixirBoilerplate.Release.migrate
+
 exec ./elixir_boilerplate start

--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+exec ./elixir_boilerplate start


### PR DESCRIPTION
## 📖 Description

Following the dependencies update in #165, here are a few changes the release/docker setup to follow the community setup introduce in `1.6` and generated by `phx.gen.release`.

## 📝 Notes

Here are the important parts:

1. In a vanilla setup, the initial `npm-builder` step could be avoided, but since we are still depending on `simple-css-reset` we need it to install it first for `esbuild` to be able to bundle it. In an ideal world, the reset is handled by the CSS framework, not an explicit dependency.

2. The "recommended" base image is Debian, not Alpine to prevent DNS resolution issue. See the comment in the generator [here](https://github.com/phoenixframework/phoenix/blob/master/priv/templates/phx.gen.release/Dockerfile.eex#L1-L2).

3. Instead of using a docker `ENTRYPOINT`, `phx.gen.release` generates shell scripts in `bin`, next to the release binary. This implies that migrations have to be explicitly instead of automatically ran each the release boots up. This might be something we want to address differently…

## 🦀 Dispatch

- `#dispatch/elixir`
