### PR TITLE
Remove “example.com” reference in .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -31,4 +31,4 @@ CANONICAL_URL=http://localhost:4001
 # CSS and JavaScript). We often use these variables to configure a CDN that
 # will cache static files once they have been served by the Phoenix
 # application.
-STATIC_URL=https://example.com:443
+STATIC_URL=http://localhost:4001


### PR DESCRIPTION
## 📖 Description

As a best practice, we shouldn’t have any _outside_ reference in our codebase, especially in files that are used in development, production and even test environment.

## 🦀 Dispatch

- `#dispatch/elixir`
