### PR TITLE
Extract the helpers module out of runtime.exs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,99 +1,42 @@
 import Config
+import ElixirBoilerplate.ConfigHelpers
 
-defmodule Environment do
-  @moduledoc """
-  This modules provides various helpers to handle environment metadata
-  """
-
-  def get(key), do: System.get_env(key)
-
-  def get_boolean(key) do
-    case get(key) do
-      "true" -> true
-      "1" -> true
-      _ -> false
-    end
-  end
-
-  def get_integer(key) do
-    case get(key) do
-      value when is_bitstring(value) -> String.to_integer(value)
-      _ -> nil
-    end
-  end
-
-  def get_cors_origins do
-    case Environment.get("CORS_ALLOWED_ORIGINS") do
-      origins when is_bitstring(origins) ->
-        origins
-        |> String.split(",")
-        |> case do
-          [origin] -> origin
-          origins -> origins
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  def get_endpoint_url_config(nil), do: nil
-  def get_endpoint_url_config(""), do: nil
-
-  def get_endpoint_url_config(uri) do
-    [
-      host: uri.host,
-      scheme: uri.scheme,
-      port: uri.port
-    ]
-  end
-
-  def get_uri_part(%URI{host: host}, :host), do: host
-  def get_uri_part(%URI{port: port}, :port), do: port
-  def get_uri_part(%URI{scheme: scheme}, :scheme), do: scheme
-  def get_uri_part(_, _), do: nil
-
-  def get_safe_uri(nil), do: nil
-  def get_safe_uri(""), do: nil
-  def get_safe_uri(url), do: URI.parse(url)
-end
-
-canonical_uri = Environment.get_safe_uri(Environment.get("CANONICAL_URL"))
-static_uri = Environment.get_safe_uri(Environment.get("STATIC_URL"))
+canonical_uri = get_env("CANONICAL_URL", :uri)
+static_uri = get_env("STATIC_URL", :uri)
 
 config :elixir_boilerplate,
-  canonical_host: Environment.get_uri_part(canonical_uri, :host),
-  force_ssl: Environment.get_uri_part(canonical_uri, :scheme) == "https"
+  canonical_host: get_uri_part(canonical_uri, :host),
+  force_ssl: get_uri_part(canonical_uri, :scheme) == "https"
 
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
-  pool_size: Environment.get_integer("DATABASE_POOL_SIZE"),
-  ssl: Environment.get_boolean("DATABASE_SSL"),
-  url: Environment.get("DATABASE_URL")
+  url: get_env!("DATABASE_URL"),
+  ssl: get_env("DATABASE_SSL", :boolean),
+  pool_size: get_env!("DATABASE_POOL_SIZE", :integer)
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
-  debug_errors: Environment.get_boolean("DEBUG_ERRORS"),
-  http: [port: Environment.get("PORT")],
-  secret_key_base: Environment.get("SECRET_KEY_BASE"),
-  static_url: Environment.get_endpoint_url_config(static_uri),
-  url: Environment.get_endpoint_url_config(canonical_uri)
+  http: [port: get_env!("PORT", :integer)],
+  secret_key_base: get_env!("SECRET_KEY_BASE"),
+  url: get_endpoint_url_config(canonical_uri),
+  static_url: get_endpoint_url_config(static_uri),
+  debug_errors: get_env("DEBUG_ERRORS", :boolean)
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Router,
-  session_key: Environment.get("SESSION_KEY"),
-  session_signing_salt: Environment.get("SESSION_SIGNING_SALT")
+  session_key: get_env!("SESSION_KEY"),
+  session_signing_salt: get_env!("SESSION_SIGNING_SALT")
 
-config :elixir_boilerplate, Corsica, origins: Environment.get_cors_origins()
+config :elixir_boilerplate, Corsica, origins: get_env("CORS_ALLOWED_ORIGINS", :cors)
 
 config :elixir_boilerplate,
   basic_auth: [
-    username: Environment.get("BASIC_AUTH_USERNAME"),
-    password: Environment.get("BASIC_AUTH_PASSWORD")
+    username: get_env("BASIC_AUTH_USERNAME"),
+    password: get_env("BASIC_AUTH_PASSWORD")
   ]
 
 config :sentry,
-  dsn: Environment.get("SENTRY_DSN"),
-  environment_name: Environment.get("SENTRY_ENVIRONMENT_NAME"),
-  included_environments: [Environment.get("SENTRY_ENVIRONMENT_NAME")]
+  dsn: get_env("SENTRY_DSN"),
+  environment_name: get_env("SENTRY_ENVIRONMENT_NAME"),
+  included_environments: [get_env("SENTRY_ENVIRONMENT_NAME")]
 
 config :new_relic_agent,
-  app_name: System.get_env("NEW_RELIC_APP_NAME"),
-  license_key: System.get_env("NEW_RELIC_LICENSE_KEY")
+  app_name: get_env("NEW_RELIC_APP_NAME"),
+  license_key: get_env("NEW_RELIC_LICENSE_KEY")

--- a/lib/config_helpers.ex
+++ b/lib/config_helpers.ex
@@ -1,0 +1,52 @@
+defmodule ElixirBoilerplate.ConfigHelpers do
+  @moduledoc """
+  This modules provides various helpers to handle environment metadata
+  """
+
+  @type value_type :: :string | :integer | :boolean | :uri | :cors
+  @type config_type :: String.t() | integer() | boolean() | URI.t() | [String.t()]
+
+  @spec get_env(String.t(), nil | value_type()) :: config_type()
+  def get_env(key, type \\ :string) do
+    System.get_env(key)
+    |> parse_env(type)
+  end
+
+  @spec get_env!(String.t(), nil | value_type()) :: config_type()
+  def get_env!(key, type \\ :string) do
+    System.fetch_env!(key)
+    |> parse_env(type)
+  end
+
+  defp parse_env(value, :string), do: value
+  defp parse_env(value, :integer), do: String.to_integer(value)
+
+  defp parse_env(nil, :boolean), do: false
+  defp parse_env("", :boolean), do: false
+  defp parse_env(value, :boolean), do: String.downcase(value) in ~w(true 1)
+
+  defp parse_env(nil, :cors), do: nil
+
+  defp parse_env(value, :cors) when is_bitstring(value) do
+    value
+    |> String.split(",")
+    |> case do
+      [origin] -> origin
+      origins -> origins
+    end
+  end
+
+  defp parse_env(nil, :uri), do: nil
+  defp parse_env("", :uri), do: nil
+  defp parse_env(value, :uri), do: URI.parse(value)
+
+  @spec get_endpoint_url_config(URI.t() | any()) :: nil | [scheme: String.t(), host: String.t(), port: String.t()]
+  def get_endpoint_url_config(%URI{scheme: scheme, host: host, port: port}), do: [scheme: scheme, host: host, port: port]
+  def get_endpoint_url_config(_invalid), do: nil
+
+  @spec get_uri_part(URI.t() | any(), :scheme | :host | :port) :: String.t() | nil
+  def get_uri_part(%URI{scheme: scheme}, :scheme), do: scheme
+  def get_uri_part(%URI{host: host}, :host), do: host
+  def get_uri_part(%URI{port: port}, :port), do: port
+  def get_uri_part(_invalid, _part), do: nil
+end


### PR DESCRIPTION
## 📖 Description

I was reading [this blog post](https://felt.com/blog/elixir-configuration) by @axelson yesterday and I really liked the approach proposed in point #2, especially the reference to the `ConfigHelpers` module from the Code::Stats repository!

> 2. **Use configuration helpers.** I like to use configuration helpers which are inspired by this [file](https://gitlab.com/code-stats/code-stats/-/blob/b1cf53462a3fa34369eaa06494754c7ae38aed2a/lib/code_stats/config_helpers.ex). Using configuration helpers like this eases the burden of converting string environment variables into their proper form which may be a boolean or an integer. Once I have the config helpers imported I can read an environment variable with `get_env("RUN_SEEDS_ON_STARTUP", false, :boolean)` where false is the default if the environment variable `RUN_SEEDS_ON_STARTUP` is not provided and `:boolean` means to parse the environment variable into either false or true (any values that can’t be parsed to one of those is treated as an error). 

It’s a similar approach, but it simplifies `runtime.exs` to makes it significantly easier to read and understand.

## 📓 References

- [Tips for Improving Your Elixir Configuration](https://felt.com/blog/elixir-configuration)
- `ConfigHelpers` module from the [`Code::Stats` repository](https://gitlab.com/code-stats/code-stats/-/blob/b1cf53462a3fa34369eaa06494754c7ae38aed2a/lib/code_stats/config_helpers.ex)

## 🦀 Dispatch

- `#dispatch/elixir`
