### PR TITLE
Add priv/null as source and custom Interpolation module for gettext in test env

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -21,6 +21,6 @@ config :elixir_boilerplate, ElixirBoilerplate.Repo,
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint, server: false
 
 # This config is to output keys instead of translated message in test
-config :elixir_boilerplate, ElixirBoilerplate.Gettext, priv: "priv/null"
+config :elixir_boilerplate, ElixirBoilerplate.Gettext, priv: "priv/null", interpolation: ElixirBoilerplate.GettextInterpolation
 
 config :logger, level: :warn

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,4 +20,7 @@ config :elixir_boilerplate, ElixirBoilerplate.Repo,
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint, server: false
 
+# This config is to output keys instead of translated message in test
+config :elixir_boilerplate, ElixirBoilerplate.Gettext, priv: "priv/null"
+
 config :logger, level: :warn

--- a/test/elixir_boilerplate/gettext_interpolation_test.exs
+++ b/test/elixir_boilerplate/gettext_interpolation_test.exs
@@ -1,0 +1,4 @@
+defmodule ElixirBoilerplate.GettextInterpolationTest do
+  use ExUnit.Case, async: true
+  doctest ElixirBoilerplate.GettextInterpolation, import: true
+end

--- a/test/elixir_boilerplate_web/errors_test.exs
+++ b/test/elixir_boilerplate_web/errors_test.exs
@@ -64,9 +64,9 @@ defmodule ElixirBoilerplateWeb.ErrorsTest do
       |> changeset_to_error_messages()
 
     assert html =~ "<li>email has invalid format</li>"
-    assert html =~ "<li>email should be 10 characters</li>"
-    assert html =~ "<li>multiple_roles.type can’t be blank</li>"
-    assert html =~ "<li>nicknames should have at least 1 item</li>"
+    assert html =~ "<li>email should be 10 character(s)</li>"
+    assert html =~ "<li>multiple_roles.type can&#39;t be blank</li>"
+    assert html =~ "<li>nicknames should have at least 1 item(s)</li>"
     assert html =~ "<li>single_role.type is invalid</li>"
   end
 

--- a/test/elixir_boilerplate_web/errors_test.exs
+++ b/test/elixir_boilerplate_web/errors_test.exs
@@ -28,6 +28,7 @@ defmodule ElixirBoilerplateWeb.ErrorsTest do
     import Ecto.Changeset
 
     schema "users" do
+      field(:username, :string)
       field(:email, :string)
       field(:nicknames, {:array, :string})
 
@@ -42,6 +43,7 @@ defmodule ElixirBoilerplateWeb.ErrorsTest do
       |> cast(params, [:email, :nicknames])
       |> cast_embed(:single_role)
       |> cast_embed(:multiple_roles)
+      |> validate_required(:username)
       |> validate_length(:email, is: 10)
       |> validate_length(:nicknames, min: 1)
       |> validate_format(:email, ~r/@/)
@@ -63,11 +65,11 @@ defmodule ElixirBoilerplateWeb.ErrorsTest do
       |> User.changeset(%{"email" => "foo", "nicknames" => [], "single_role" => %{"type" => "bar"}, "multiple_roles" => [%{"type" => ""}]})
       |> changeset_to_error_messages()
 
-    assert html =~ "<li>email has invalid format</li>"
-    assert html =~ "<li>email should be 10 character(s)</li>"
-    assert html =~ "<li>multiple_roles.type can&#39;t be blank</li>"
-    assert html =~ "<li>nicknames should have at least 1 item(s)</li>"
-    assert html =~ "<li>single_role.type is invalid</li>"
+    assert html =~ "<li>email has invalid format[validation=:format]</li>"
+    assert html =~ "<li>email should be %{count} character(s)[count=10,kind=:is,type=:string,validation=:length]</li>"
+    assert html =~ "<li>multiple_roles.type can&#39;t be blank[validation=:required]</li>"
+    assert html =~ "<li>nicknames should have at least %{count} item(s)[count=1,kind=:min,type=:list,validation=:length]</li>"
+    assert html =~ "<li>single_role.type is invalid[enum=admin,moderator,member,validation=:inclusion]</li>"
   end
 
   defp changeset_to_error_messages(changeset) do

--- a/test/support/gettext_interpolation.ex
+++ b/test/support/gettext_interpolation.ex
@@ -1,0 +1,47 @@
+defmodule ElixirBoilerplate.GettextInterpolation do
+  @moduledoc """
+  Default Gettext.Interpolation implementation for testing purposes
+
+  Appends formatted `bindings` at the end of the string
+  """
+
+  @behaviour Gettext.Interpolation
+
+  @doc """
+  iex> runtime_interpolate("test", %{})
+  {:ok, "test"}
+  iex> runtime_interpolate("test", %{arg: 1})
+  {:ok, "test[arg=1]"}
+  iex> runtime_interpolate("test", %{arg: :atom})
+  {:ok, "test[arg=:atom]"}
+  iex> runtime_interpolate("test", %{arg: [:atom,:atom2]})
+  {:ok, "test[arg=:atom,:atom2]"}
+  """
+  @impl true
+  def runtime_interpolate(message, bindings), do: {:ok, format(message, bindings)}
+
+  @impl true
+  defmacro compile_interpolate(_message_type, message, bindings) do
+    quote do
+      runtime_interpolate(unquote(message), unquote(bindings))
+    end
+  end
+
+  @impl true
+  def message_format, do: "test-format"
+
+  defp format(message, bindings), do: "#{message}#{format_bindings(bindings)}"
+
+  defp format_bindings(bindings) when is_map(bindings) and map_size(bindings) === 0, do: ""
+
+  defp format_bindings(bindings) when is_map(bindings) do
+    bindings = Enum.map_join(bindings, ",", fn {key, value} -> "#{key}=#{format_value(value)}" end)
+    "[#{bindings}]"
+  end
+
+  defp format_bindings(_bindings), do: ""
+
+  defp format_value(value) when is_list(value), do: Enum.map_join(value, ",", &format_value/1)
+  defp format_value(value) when is_binary(value), do: value
+  defp format_value(value), do: inspect(value)
+end


### PR DESCRIPTION
## 📖 Description

The goal is to have the key as output in templates. This way, we can test the content without relying on `po` files.
With the custom Interpolation module, bindings are also printed in the templates

```elixir
Gettext.dgettext(ElixirBoilerplate.Gettext, "errors", "test", %{arg: "ok"})
#=> test[arg=ok]
```

## 🦀 Dispatch

- `#dispatch/elixir`
