### PR TITLE
Correcly rename the release scripts added in #166 when running ./boilerplate-setup.sh

### DIFF
--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -10,23 +10,24 @@ kebabCaseBefore="elixir-boilerplate"
 
 # The identifiers above will be replaced in the content of the files found below
 content=$(find . -type f \( \
-  -name "*.ex" -or \
-  -name "*.exs" -or \
-  -name "*.ees" -or \
-  -name "*.sh" -or \
-  -name "*.json" -or \
-  -name "*.js" -or \
-  -name "*.yml" -or \
-  -name "*.yaml" -or \
-  -name "*.md" -or \
-  -name ".env.*" -or \
-  -name "Dockerfile" -or \
-  -name "Makefile" \
-\) \
-  -and ! -path "./boilerplate-setup.sh" \
-  -and ! -path "./assets/node_modules/*" \
-  -and ! -path "./_build/*" \
-  -and ! -path "./deps/*" \
+    -name "*.ex" -or \
+    -name "*.exs" -or \
+    -name "*.ees" -or \
+    -name "*.sh" -or \
+    -name "*.json" -or \
+    -name "*.js" -or \
+    -name "*.yml" -or \
+    -name "*.yaml" -or \
+    -name "*.md" -or \
+    -name ".env.*" -or \
+    -name "Dockerfile" -or \
+    -name "Makefile" -or \
+    -path "./rel/overlays/bin/*" \
+  \) -and \
+  ! -path "./boilerplate-setup.sh" -and \
+  ! -path "./deps/*" -and \
+  ! -path "./_build/*" -and \
+  ! -path "./assets/node_modules/*" \
 )
 
 # The identifiers above will be replaced in the path of the files and directories found here


### PR DESCRIPTION
## 📖 Description

Following the `mix phx.gen.release` recipe, we added two scripts in `rel/overlays/bin` to start the release inside the Docker container, but the path was not included to replace the application name in!

## 🦀 Dispatch

- `#dispatch/elixir`
