### PR TITLE
Add OperationNameLogger Absinthe middleware

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,4 +7,4 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   level: :info,
-  metadata: ~w(request_id)a
+  metadata: ~w(request_id graphql_operation_name)a

--- a/lib/elixir_boilerplate_graphql/operation_name_logger.ex
+++ b/lib/elixir_boilerplate_graphql/operation_name_logger.ex
@@ -1,0 +1,14 @@
+defmodule ElixirBoilerplateGraphQL.OperationNameLogger do
+  @behaviour Absinthe.Middleware
+
+  def call(resolution, _opts) do
+    current_operation = Enum.find(resolution.path, &current_operation?/1)
+
+    Logger.metadata(graphql_operation_name: current_operation.name)
+
+    resolution
+  end
+
+  defp current_operation?(%Absinthe.Blueprint.Document.Operation{current: true}), do: true
+  defp current_operation?(_), do: false
+end

--- a/lib/elixir_boilerplate_graphql/operation_name_logger.ex
+++ b/lib/elixir_boilerplate_graphql/operation_name_logger.ex
@@ -2,9 +2,9 @@ defmodule ElixirBoilerplateGraphQL.OperationNameLogger do
   @behaviour Absinthe.Middleware
 
   def call(resolution, _opts) do
-    current_operation = Enum.find(resolution.path, &current_operation?/1)
-
-    Logger.metadata(graphql_operation_name: current_operation.name)
+    with %Absinthe.Blueprint.Document.Operation{name: name} <- Enum.find(resolution.path, &current_operation?/1) do
+      Logger.metadata(graphql_operation_name: name)
+    end
 
     resolution
   end

--- a/lib/elixir_boilerplate_graphql/operation_name_logger.ex
+++ b/lib/elixir_boilerplate_graphql/operation_name_logger.ex
@@ -5,8 +5,11 @@ defmodule ElixirBoilerplateGraphQL.OperationNameLogger do
 
   def call(resolution, _opts) do
     case Enum.find(resolution.path, &current_operation?/1) do
-      %Operation{name: name} when not is_nil(name) -> Logger.metadata(graphql_operation_name: name)
-      _ -> Logger.metadata(graphql_operation_name: "#NULL")
+      %Operation{name: name} when not is_nil(name) ->
+        Logger.metadata(graphql_operation_name: name)
+
+      _ ->
+        Logger.metadata(graphql_operation_name: "#NULL")
     end
 
     resolution

--- a/lib/elixir_boilerplate_graphql/operation_name_logger.ex
+++ b/lib/elixir_boilerplate_graphql/operation_name_logger.ex
@@ -1,14 +1,18 @@
 defmodule ElixirBoilerplateGraphQL.OperationNameLogger do
   @behaviour Absinthe.Middleware
 
+  alias Absinthe.Blueprint.Document.Operation
+
   def call(resolution, _opts) do
-    with %Absinthe.Blueprint.Document.Operation{name: name} <- Enum.find(resolution.path, &current_operation?/1) do
+    with %Operation{name: name} when not is_nil(name) <- Enum.find(resolution.path, &current_operation?/1) do
       Logger.metadata(graphql_operation_name: name)
+    else
+      _ -> Logger.metadata(graphql_operation_name: "#NULL")
     end
 
     resolution
   end
 
-  defp current_operation?(%Absinthe.Blueprint.Document.Operation{current: true}), do: true
+  defp current_operation?(%Operation{current: true}), do: true
   defp current_operation?(_), do: false
 end

--- a/lib/elixir_boilerplate_graphql/operation_name_logger.ex
+++ b/lib/elixir_boilerplate_graphql/operation_name_logger.ex
@@ -4,9 +4,8 @@ defmodule ElixirBoilerplateGraphQL.OperationNameLogger do
   alias Absinthe.Blueprint.Document.Operation
 
   def call(resolution, _opts) do
-    with %Operation{name: name} when not is_nil(name) <- Enum.find(resolution.path, &current_operation?/1) do
-      Logger.metadata(graphql_operation_name: name)
-    else
+    case Enum.find(resolution.path, &current_operation?/1) do
+      %Operation{name: name} when not is_nil(name) -> Logger.metadata(graphql_operation_name: name)
       _ -> Logger.metadata(graphql_operation_name: "#NULL")
     end
 

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -26,6 +26,6 @@ defmodule ElixirBoilerplateGraphQL.Schema do
   end
 
   def middleware(middleware, _, _) do
-    [NewRelic.Absinthe.Middleware] ++ middleware
+    [NewRelic.Absinthe.Middleware, ElixirBoilerplateGraphQL.OperationNameLogger] ++ middleware
   end
 end


### PR DESCRIPTION
## 📖 Description

This is a pattern we have a few production projects that we haven’t yet brought back to the boilerplate.

In production logs, we have:

```
20:33:56.107 request_id=FxtToINh7z7RLpsAAAKB [info] POST /graphql
20:33:56.239 request_id=FxtToINh7z7RLpsAAAKB [info] Sent 200 in 84ms
```

which is not that useful because **all requests to our GraphQL API** are sent to `/graphql` via a `POST` HTTP request.

With this new Absinthe middleware, we log the GraphQL operation name (if any, otherwise the `graphql_operation_name` isn’t shown):

```
20:33:56.107 request_id=FxtToINh7z7RLpsAAAKB [info] POST /graphql
20:33:56.239 request_id=FxtToINh7z7RLpsAAAKB graphql_operation_name=Foo [info] Sent 200 in 84ms
```

## 📝 Notes

In other projects, we use Absinthe’s `pipeline` option to do this, but I think it’s much simpler using a middleware.

## 🦀 Dispatch

- `#dispatch/elixir`
