### PR TITLE
Add CI workflow concurrency configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📖 Description

GitHub allows us to configure a [concurrency property](https://docs.github.com/en/actions/using-jobs/using-concurrency) to avoid useless workflow runs.

## 🦀 Dispatch

- `#dispatch/devops`
