### PR TITLE
Use versions from .tool-versions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
             deps
             _build
             priv/plts
-          key: ${{ runner.os }}-mix-${{ setup-beam.otp-version }}-${{ setup-beam.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
+          key: ${{ runner.os }}-mix-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,6 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otp-version: [25.0]
-        elixir-version: [1.13]
 
     services:
       db:
@@ -36,10 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
+        id: setup-beam
         with:
-          otp-version: ${{ matrix.otp-version }}
-          elixir-version: ${{ matrix.elixir-version }}
+          version-file: .tool-versions
 
       - uses: actions/cache@v3
         with:
@@ -47,12 +43,12 @@ jobs:
             deps
             _build
             priv/plts
-          key: ${{ runner.os }}-mix-${{ matrix.otp-version }}-${{ matrix.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
+          key: ${{ runner.os }}-mix-${{ setup-beam.otp-version }}-${{ setup-beam.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.15
-          cache: 'npm'
+          node-version-file: .tool-versions
+          cache: npm
 
       - name: Setup environment variables
         uses: c-py/action-dotenv-to-setenv@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         id: setup-beam
         with:
           version-file: .tool-versions
+          version-type: strict
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
## 📖 Description

Instead of manually having to update the CI workflow file, we can leverage recently merged functionality (https://github.com/actions/setup-node/pull/373 & https://github.com/erlef/setup-beam/pull/159) to automatize this.

## 🦀 Dispatch

- `#dispatch/devops`
