### PR TITLE
Add missing `DATABASE_SSL` variable to .env.dev

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -24,7 +24,7 @@ SESSION_SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
 # - Use `postgres://postgres:development@localhost/elixir_boilerplate_dev` if you’re using the PostgreSQL server provided by Docker Compose
 DATABASE_URL=postgres://localhost/elixir_boilerplate_dev
 DATABASE_POOL_SIZE=20
-DATABASE_SSL=20
+DATABASE_SSL=false
 
 # URL configuration (used by Phoenix to build URLs from routes)
 # Other features also extracts values from this URL:

--- a/.env.dev
+++ b/.env.dev
@@ -24,6 +24,7 @@ SESSION_SIGNING_SALT= # Generate salt with `mix phx.gen.secret`
 # - Use `postgres://postgres:development@localhost/elixir_boilerplate_dev` if you’re using the PostgreSQL server provided by Docker Compose
 DATABASE_URL=postgres://localhost/elixir_boilerplate_dev
 DATABASE_POOL_SIZE=20
+DATABASE_SSL=20
 
 # URL configuration (used by Phoenix to build URLs from routes)
 # Other features also extracts values from this URL:


### PR DESCRIPTION
## 📖 Description

We have a `DATABASE_SSL` environment variable but it was not documented anywhere.

## 🦀 Dispatch

- `#dispatch/elixir`
