### PR TITLE
Add Plugs.Security in main endpoint, not individual routers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,7 @@ config :elixir_boilerplate, Corsica, allow_headers: :all
 
 config :elixir_boilerplate, ElixirBoilerplate.Gettext, default_locale: "en"
 
-config :elixir_boilerplate, ElixirBoilerplateWeb.ContentSecurityPolicy, allow_unsafe_scripts: false
+config :elixir_boilerplate, ElixirBoilerplateWeb.Plus.Security, allow_unsafe_scripts: false
 
 config :esbuild,
   version: "0.14.41",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,7 +14,7 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
     ]
   ]
 
-config :elixir_boilerplate, ElixirBoilerplateWeb.ContentSecurityPolicy, allow_unsafe_scripts: true
+config :elixir_boilerplate, ElixirBoilerplateWeb.Plugs.Security, allow_unsafe_scripts: true
 
 config :logger, :console, format: "[$level] $message\n"
 

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -49,6 +49,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 
+  plug(ElixirBoilerplateWeb.Plugs.Security)
   plug(ElixirBoilerplateHealth.Router)
   plug(ElixirBoilerplateGraphQL.Router)
   plug(:halt_if_sent)

--- a/lib/elixir_boilerplate_web/plugs/security.ex
+++ b/lib/elixir_boilerplate_web/plugs/security.ex
@@ -1,12 +1,15 @@
-defmodule ElixirBoilerplateWeb.ContentSecurityPolicy do
+defmodule ElixirBoilerplateWeb.Plugs.Security do
   @doc """
-  This plug adds a “Content-Security-Policy” header to responses. You will
-  need to customize each directive to fit your application needs.
+  This plug adds Phoenix secure HTTP headers including a
+  “Content-Security-Policy” header to responses.You will need to customize each
+  policy directive to fit your application needs.
   """
 
-  use Plug.Builder
+  @behaviour Plug
 
   import Phoenix.Controller, only: [put_secure_browser_headers: 2]
+
+  def init(opts), do: opts
 
   def call(conn, _) do
     directives = [

--- a/lib/elixir_boilerplate_web/router.ex
+++ b/lib/elixir_boilerplate_web/router.ex
@@ -9,7 +9,6 @@ defmodule ElixirBoilerplateWeb.Router do
     plug(:fetch_flash)
 
     plug(:protect_from_forgery)
-    plug(ElixirBoilerplateWeb.ContentSecurityPolicy)
 
     plug(:put_layout, {ElixirBoilerplateWeb.Layouts.View, :app})
   end


### PR DESCRIPTION
## 📖 Description

We had a module (`FooWeb.ContentSecurityPolicy`) to provide secure HTTP headers (including a custom `Content-Security-Policy`) that we were injecting in our main router.

But what about our Health and GraphQL routers? 🙅‍♂️

Not anymore! We now have a `FooWeb.Plugs.Security` module (that does the same thing as the existing one) that we inject in `FooWeb.Endpoint` instead. Problem solved!

## 🦀 Dispatch

- `#dispatch/elixir`
