### PR TITLE
Disable GraphQL introspection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `main` branch should always be stable and usable.
 
+## 2023-02-06
+
+- Disable GraphQL introspection by default (#245)
+
 ## 2023-01-27
 
 - Add security HTTP headers for the whole endpoint (#241)

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,8 @@ config :elixir_boilerplate, ElixirBoilerplate.Gettext, default_locale: "en"
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Plus.Security, allow_unsafe_scripts: false
 
+config :elixir_boilerplate, ElixirBoilerplateGraphQL, enable_introspection: false
+
 config :esbuild,
   version: "0.14.41",
   default: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,6 +16,8 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Plugs.Security, allow_unsafe_scripts: true
 
+config :elixir_boilerplate, ElixirBoilerplateGraphQL, enable_introspection: true
+
 config :logger, :console, format: "[$level] $message\n"
 
 config :phoenix, :stacktrace_depth, 20

--- a/lib/elixir_boilerplate_graphql/pipeline/introspection.ex
+++ b/lib/elixir_boilerplate_graphql/pipeline/introspection.ex
@@ -1,0 +1,7 @@
+defmodule ElixirBoilerplateGraphQL.Pipeline.Introspection do
+  if Application.compile_env(:elixir_boilerplate, ElixirBoilerplateGraphQL)[:enable_introspection] do
+    def pipeline(pipeline), do: pipeline
+  else
+    def pipeline(pipeline), do: Absinthe.Pipeline.without(pipeline, Absinthe.Phase.Schema.Introspection)
+  end
+end

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -3,6 +3,20 @@ defmodule ElixirBoilerplateGraphQL.Schema do
 
   alias ElixirBoilerplate.Repo
 
+  defmodule Introspection do
+    @disable_introspection Application.compile_env(:elixir_boilerplate, ElixirBoilerplateGraphQL)[:enable_introspection]
+
+    def pipeline(pipeline) do
+      if @disable_introspection do
+        pipeline
+      else
+        Absinthe.Pipeline.without(pipeline, Absinthe.Phase.Schema.Introspection)
+      end
+    end
+  end
+
+  @pipeline_modifier Introspection
+
   import_types(Absinthe.Type.Custom)
   import_types(ElixirBoilerplateGraphQL.Application.Types)
 

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -3,17 +3,7 @@ defmodule ElixirBoilerplateGraphQL.Schema do
 
   alias ElixirBoilerplate.Repo
 
-  defmodule Introspection do
-    @enable_introspection Application.compile_env(:elixir_boilerplate, ElixirBoilerplateGraphQL)[:enable_introspection]
-
-    if @enable_introspection do
-      def pipeline(pipeline), do: pipeline
-    else
-      def pipeline(pipeline), do: Absinthe.Pipeline.without(pipeline, Absinthe.Phase.Schema.Introspection)
-    end
-  end
-
-  @pipeline_modifier Introspection
+  @pipeline_modifier ElixirBoilerplateGraphQL.Pipeline.Introspection
 
   import_types(Absinthe.Type.Custom)
   import_types(ElixirBoilerplateGraphQL.Application.Types)

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -4,14 +4,12 @@ defmodule ElixirBoilerplateGraphQL.Schema do
   alias ElixirBoilerplate.Repo
 
   defmodule Introspection do
-    @disable_introspection Application.compile_env(:elixir_boilerplate, ElixirBoilerplateGraphQL)[:enable_introspection]
+    @enable_introspection Application.compile_env(:elixir_boilerplate, ElixirBoilerplateGraphQL)[:enable_introspection]
 
-    def pipeline(pipeline) do
-      if @disable_introspection do
-        pipeline
-      else
-        Absinthe.Pipeline.without(pipeline, Absinthe.Phase.Schema.Introspection)
-      end
+    if @enable_introspection do
+      def pipeline(pipeline), do: pipeline
+    else
+      def pipeline(pipeline), do: Absinthe.Pipeline.without(pipeline, Absinthe.Phase.Schema.Introspection)
     end
   end
 


### PR DESCRIPTION
## 📖 Description

We want to [disable introspection](https://www.apollographql.com/blog/graphql/security/why-you-should-disable-graphql-introspection-in-production/) by default for GraphQL APIs.

## 📝 Notes

Absinthe requires modifying the [pipeline](https://hexdocs.pm/absinthe/Absinthe.Pipeline.html) at compile-time, so a runtime environment variable is out of the question. Thanks @JoeyBG for suggesting to use `Application.compile_env` and hardcoded boolean values in config files! 🎩 

## 🦀 Dispatch

- `#dispatch/elixir`
