### PR TITLE
Add support for ECTO_IPV6 env var for repo socket options

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -11,7 +11,8 @@ config :elixir_boilerplate,
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
   url: get_env!("DATABASE_URL"),
   ssl: get_env("DATABASE_SSL", :boolean),
-  pool_size: get_env!("DATABASE_POOL_SIZE", :integer)
+  pool_size: get_env!("DATABASE_POOL_SIZE", :integer),
+  socket_options: if(get_env("ECTO_IPV6", :boolean), do: [:inet6], else: [])
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   http: [port: get_env!("PORT", :integer)],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,7 +12,7 @@ config :elixir_boilerplate, ElixirBoilerplate.Repo,
   url: get_env!("DATABASE_URL"),
   ssl: get_env("DATABASE_SSL", :boolean),
   pool_size: get_env!("DATABASE_POOL_SIZE", :integer),
-  socket_options: if(get_env("ECTO_IPV6", :boolean), do: [:inet6], else: [])
+  socket_options: if(get_env("DATABASE_IPV6", :boolean), do: [:inet6], else: [])
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   http: [port: get_env!("PORT", :integer)],


### PR DESCRIPTION
## 📖 Description

This has been merged in `phoenix` for a long time. There is no drawback in our setup, just less headaches if we want to deploy our app in a different provider like fly.io.

## 🦀 Dispatch

- `#dispatch/elixir`
