### PR TITLE
Revert "Disable GraphQL introspection by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `main` branch should always be stable and usable.
 
-## 2023-02-06
-
-- Disable GraphQL introspection by default (#245)
-
 ## 2023-01-27
 
 - Add security HTTP headers for the whole endpoint (#241)

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,8 +20,6 @@ config :elixir_boilerplate, ElixirBoilerplate.Gettext, default_locale: "en"
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Plus.Security, allow_unsafe_scripts: false
 
-config :elixir_boilerplate, ElixirBoilerplateGraphQL, enable_introspection: false
-
 config :esbuild,
   version: "0.14.41",
   default: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,8 +16,6 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Plugs.Security, allow_unsafe_scripts: true
 
-config :elixir_boilerplate, ElixirBoilerplateGraphQL, enable_introspection: true
-
 config :logger, :console, format: "[$level] $message\n"
 
 config :phoenix, :stacktrace_depth, 20

--- a/lib/elixir_boilerplate_graphql/pipeline/introspection.ex
+++ b/lib/elixir_boilerplate_graphql/pipeline/introspection.ex
@@ -1,7 +1,0 @@
-defmodule ElixirBoilerplateGraphQL.Pipeline.Introspection do
-  if Application.compile_env(:elixir_boilerplate, ElixirBoilerplateGraphQL)[:enable_introspection] do
-    def pipeline(pipeline), do: pipeline
-  else
-    def pipeline(pipeline), do: Absinthe.Pipeline.without(pipeline, Absinthe.Phase.Schema.Introspection)
-  end
-end

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -3,8 +3,6 @@ defmodule ElixirBoilerplateGraphQL.Schema do
 
   alias ElixirBoilerplate.Repo
 
-  @pipeline_modifier ElixirBoilerplateGraphQL.Pipeline.Introspection
-
   import_types(Absinthe.Type.Custom)
   import_types(ElixirBoilerplateGraphQL.Application.Types)
 


### PR DESCRIPTION
Removing `Absinthe.Phase.Schema.Introspection` was a bad idea — it breaks client requests (that use `__typeName`) 😬 

We’re going to be testing how [Apollo does it](https://github.com/apollographql/apollo-server/blob/main/packages/server/src/ApolloServer.ts#L76-L93) and then merge it back here.

This reverts mirego/elixir-boilerplate#245