### PR TITLE
Replace backticks with “shell” make utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # Build configuration
 # -------------------
 
-APP_NAME = `grep -Eo 'app: :\w*' mix.exs | cut -d ':' -f 3`
-APP_VERSION = `grep -Eo 'version: "[0-9\.]*"' mix.exs | cut -d '"' -f 2`
-GIT_REVISION = `git rev-parse HEAD`
+APP_NAME := $(shell grep -Eo 'app: :\w*' mix.exs | cut -d ':' -f 3)
+APP_VERSION := $(shell grep -Eo 'version: "[0-9\.]*"' mix.exs | cut -d '"' -f 2)
+GIT_REVISION := $(shell git rev-parse HEAD)
 DOCKER_IMAGE_TAG ?= $(APP_VERSION)
 DOCKER_REGISTRY ?=
-DOCKER_LOCAL_IMAGE = $(APP_NAME):$(DOCKER_IMAGE_TAG)
-DOCKER_REMOTE_IMAGE = $(DOCKER_REGISTRY)/$(DOCKER_LOCAL_IMAGE)
+DOCKER_LOCAL_IMAGE:= $(APP_NAME):$(DOCKER_IMAGE_TAG)
+DOCKER_REMOTE_IMAGE:= $(DOCKER_REGISTRY)/$(DOCKER_LOCAL_IMAGE)
 
 # Linter and formatter configuration
 # ----------------------------------


### PR DESCRIPTION
## 📖 Description

Using make’s [shell utility](https://www.gnu.org/software/make/manual/html_node/Shell-Function.html) is the right way (instead of backticks) to execute runtime commands and use outputs in targets.

## 📝 Notes

🎩 Hat tip to @Boubalou for this piece of knowledge 😄 

## 🦀 Dispatch

- `#dispatch/devops`
