### PR TITLE
Update Credo config file with recent checks

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -61,7 +61,7 @@
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},
           {Credo.Check.Refactor.NegatedConditionsWithElse, []},
           {Credo.Check.Refactor.Nesting, []},
-          {Credo.Check.Refactor.PipeChainStart, [excluded_argument_types: ~w(atom binary fn keyword)a]},
+          {Credo.Check.Refactor.PipeChainStart, [excluded_argument_types: ~w(atom binary fn keyword)a, excluded_functions: ~w(from)]},
           {Credo.Check.Refactor.UnlessWithElse, []},
           {Credo.Check.Refactor.WithClauses, []},
           {Credo.Check.Refactor.FilterFilter, []},

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,80 +1,133 @@
-common_checks = [
-  {Credo.Check.Consistency.ExceptionNames},
-  {Credo.Check.Consistency.LineEndings},
-  {Credo.Check.Consistency.SpaceAroundOperators},
-  {Credo.Check.Consistency.SpaceInParentheses},
-  {Credo.Check.Consistency.TabsOrSpaces},
-  {Credo.Check.Design.AliasUsage, if_called_more_often_than: 2, if_nested_deeper_than: 1},
-  {Credo.Check.Design.TagTODO},
-  {Credo.Check.Design.TagFIXME},
-  {Credo.Check.Readability.AliasOrder},
-  {Credo.Check.Readability.FunctionNames},
-  {Credo.Check.Readability.LargeNumbers},
-  {Credo.Check.Readability.MaxLineLength, max_length: 200},
-  {Credo.Check.Readability.ModuleAttributeNames},
-  {Credo.Check.Readability.ModuleDoc, false},
-  {Credo.Check.Readability.ModuleNames},
-  {Credo.Check.Readability.MultiAlias},
-  {Credo.Check.Readability.ParenthesesInCondition},
-  {Credo.Check.Readability.PredicateFunctionNames},
-  {Credo.Check.Readability.SinglePipe},
-  {Credo.Check.Readability.StrictModuleLayout},
-  {Credo.Check.Readability.TrailingBlankLine},
-  {Credo.Check.Readability.TrailingWhiteSpace},
-  {Credo.Check.Readability.VariableNames},
-  {Credo.Check.Refactor.ABCSize, max_size: 40},
-  {Credo.Check.Refactor.CaseTrivialMatches},
-  {Credo.Check.Refactor.CondStatements},
-  {Credo.Check.Refactor.FunctionArity},
-  {Credo.Check.Refactor.MapInto, false},
-  {Credo.Check.Refactor.MatchInCondition},
-  {Credo.Check.Refactor.PipeChainStart, excluded_argument_types: ~w(atom binary fn keyword)a, excluded_functions: ~w(from)},
-  {Credo.Check.Refactor.CyclomaticComplexity},
-  {Credo.Check.Refactor.NegatedConditionsInUnless},
-  {Credo.Check.Refactor.NegatedConditionsWithElse},
-  {Credo.Check.Refactor.Nesting},
-  {Credo.Check.Refactor.UnlessWithElse},
-  {Credo.Check.Refactor.WithClauses},
-  {Credo.Check.Warning.IExPry},
-  {Credo.Check.Warning.IoInspect},
-  {Credo.Check.Warning.LazyLogging, false},
-  {Credo.Check.Warning.OperationOnSameValues},
-  {Credo.Check.Warning.BoolOperationOnSameValues},
-  {Credo.Check.Warning.UnusedEnumOperation},
-  {Credo.Check.Warning.UnusedKeywordOperation},
-  {Credo.Check.Warning.UnusedListOperation},
-  {Credo.Check.Warning.UnusedStringOperation},
-  {Credo.Check.Warning.UnusedTupleOperation},
-  {Credo.Check.Warning.OperationWithConstantResult},
-  {CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime},
-  {CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames, terms: ["Manager", "Fetcher", "Builder", "Persister", "Serializer", ~r/^Helpers?$/i, ~r/^Utils?$/i]},
-  {CredoNaming.Check.Consistency.ModuleFilename,
-   excluded_paths: ["config", "mix.exs", "priv", "test/support"], acronyms: [{"ElixirBoilerplateGraphQL", "elixir_boilerplate_graphql"}, {"GraphQL", "graphql"}]}
-]
-
 %{
   configs: [
     %{
       name: "default",
-      strict: true,
       files: %{
-        included: ["*.exs", "lib/", "priv/", "config/", "rel/"],
-        excluded: []
+        included: ["*.exs", "lib/", "priv/", "config/", "rel/", "test/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
       },
-      checks:
-        common_checks ++
-          [
-            {Credo.Check.Design.DuplicatedCode, excluded_macros: []}
-          ]
-    },
-    %{
-      name: "test",
+      plugins: [],
+      requires: [],
       strict: true,
-      files: %{
-        included: ["test/"],
-        excluded: []
-      },
-      checks: common_checks
+      parse_timeout: 5000,
+      color: true,
+      checks: %{
+        enabled: [
+          # Consistency Checks
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          # Design Checks
+          {Credo.Check.Design.AliasUsage, [if_nested_deeper_than: 1, if_called_more_often_than: 2]},
+          {Credo.Check.Design.TagTODO, []},
+          {Credo.Check.Design.TagFIXME, []},
+
+          # Readability Checks
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 200]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, false},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
+
+          # Refactoring Opportunities
+          {Credo.Check.Refactor.ABCSize, max_size: 40},
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.PipeChainStart, [excluded_argument_types: ~w(atom binary fn keyword)a]},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+
+          # Warnings
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+
+          # Naming
+          {CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime},
+          {CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames, terms: ["Manager", "Fetcher", "Builder", "Persister", "Serializer", ~r/^Helpers?$/i, ~r/^Utils?$/i]},
+          {CredoNaming.Check.Consistency.ModuleFilename,
+           excluded_paths: ["config", "mix.exs", "priv", "test/support"], acronyms: [{"ElixirBoilerplateGraphQL", "elixir_boilerplate_graphql"}, {"GraphQL", "graphql"}]}
+        ],
+        disabled: [
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## 📖 Description

I generated a new Credo config file (`.credo.exs`) and implemented it in:

- elixir-security-advisories ([#7](https://github.com/mirego/elixir-security-advisories/pull/7))
- mix_audit ([#21](https://github.com/mirego/mix_audit/pull/21))
- <https://projetteamforward.org>’s Elixir API

With great success! So let’s bring it back here.

## 📝 Notes

There probably will be some tweaks left to work out after implementing it in larger codebases but we should be good.

## 🦀 Dispatch

- `#dispatch/elixir`
