### PR TITLE
Fix typo in GraphQL schema comment and in .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -19,7 +19,7 @@ SESSION_SIGNING_SALT=qh+vmMHsOqcjKF3TSSIsghwt2go48m2+IQ+kMTOB3BrSysSr7D4a21uAtt4
 # - Use `postgres://localhost/elixir_boilerplate_test` if you have a local PostgreSQL server
 # - Use `postgres://username:password@localhost/elixir_boilerplate_test` if you have a local PostgreSQL server with credentials
 # - Use `postgres://postgres:development@localhost/elixir_boilerplate_test` if you’re using the PostgreSQL server provided by Docker Compose
-DATABASE_URL=postgres://postgres:boilerplate@localhost/elixir_boilerplate_test
+DATABASE_URL=postgres://postgres:development@localhost/elixir_boilerplate_test
 DATABASE_POOL_SIZE=5
 
 # URL configuration (used by Phoenix to build URLs from routes)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         image: postgres:14
         env:
           POSTGRES_DB: elixir_boilerplate_test
-          POSTGRES_PASSWORD: boilerplate
+          POSTGRES_PASSWORD: development
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -10,9 +10,8 @@ defmodule ElixirBoilerplateGraphQL.Schema do
     import_fields(:application_queries)
   end
 
-  # Even if having an empty mutation block is valid and works in Absinthe, it
-  # causes a JavaScript error in GraphiQL so uncomment it when you add the
-  # first mutation.
+  # Having an empty mutation block is invalid and raises an error in Absinthe.
+  # Uncomment it when you add the first mutation.
   #
   # mutation do
   # end

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -10,8 +10,8 @@ defmodule ElixirBoilerplateGraphQL.Schema do
     import_fields(:application_queries)
   end
 
-  # Even if having an empty mutation block is valid and works in Ansinthe, it
-  # causes a Javascript error in GraphiQL so uncomment it when you add the
+  # Even if having an empty mutation block is valid and works in Absinthe, it
+  # causes a JavaScript error in GraphiQL so uncomment it when you add the
   # first mutation.
   #
   # mutation do


### PR DESCRIPTION
## 📖 Description

- `.env.test` uses the same database as the `.env.dev.local` in the repo. The password should be the same in both files.
- Typo in schema comment

## 🦀 Dispatch

- `#dispatch/elixir`
