### PR TITLE
Add error reporting and refactor graphql config

### DIFF
--- a/lib/elixir_boilerplate_graphql/elixir_boilerplate_graphql.ex
+++ b/lib/elixir_boilerplate_graphql/elixir_boilerplate_graphql.ex
@@ -1,0 +1,20 @@
+defmodule ElixirBoilerplateGraphQL do
+  alias Absinthe.Phase.Document.Result
+  alias ElixirBoilerplateGraphQL.Middleware
+
+  def configuration do
+    [
+      document_providers: [Absinthe.Plug.DocumentProvider.Default],
+      json_codec: Phoenix.json_library(),
+      schema: ElixirBoilerplateGraphQL.Schema,
+      pipeline: {__MODULE__, :absinthe_pipeline}
+    ]
+  end
+
+  def absinthe_pipeline(config, opts) do
+    config
+    |> Absinthe.Plug.default_pipeline(opts)
+    |> Absinthe.Pipeline.insert_before(Result, Middleware.OperationNameLogger)
+    |> Absinthe.Pipeline.insert_after(Result, Middleware.ErrorReporting)
+  end
+end

--- a/lib/elixir_boilerplate_graphql/middleware/error_reporting.ex
+++ b/lib/elixir_boilerplate_graphql/middleware/error_reporting.ex
@@ -1,0 +1,28 @@
+defmodule ElixirBoilerplateGraphQL.Middleware.ErrorReporting do
+  defmodule Error do
+    defexception [:message]
+  end
+
+  def run(%{result: %{errors: errors}, source: source} = blueprint, options) when not is_nil(errors) do
+    Sentry.capture_exception(
+      %Error{
+        message: "Invalid GraphQL response"
+      },
+      extra: %{
+        operation_name: operation_name(Absinthe.Blueprint.current_operation(blueprint)),
+        variables: Keyword.get(options, :variables, %{}),
+        errors: errors,
+        source: source
+      }
+    )
+
+    {:ok, blueprint}
+  end
+
+  def run(blueprint, _) do
+    {:ok, blueprint}
+  end
+
+  defp operation_name(nil), do: nil
+  defp operation_name(operation), do: operation.name
+end

--- a/lib/elixir_boilerplate_graphql/middleware/operation_name_logger.ex
+++ b/lib/elixir_boilerplate_graphql/middleware/operation_name_logger.ex
@@ -1,20 +1,8 @@
 defmodule ElixirBoilerplateGraphQL.Middleware.OperationNameLogger do
-  @behaviour Absinthe.Middleware
+  def run(blueprint, _opts) do
+    operation_name = Absinthe.Blueprint.current_operation(blueprint).name || "#NULL"
+    Logger.metadata(graphql_operation_name: operation_name)
 
-  alias Absinthe.Blueprint.Document.Operation
-
-  def call(resolution, _opts) do
-    case Enum.find(resolution.path, &current_operation?/1) do
-      %Operation{name: name} when not is_nil(name) ->
-        Logger.metadata(graphql_operation_name: name)
-
-      _ ->
-        Logger.metadata(graphql_operation_name: "#NULL")
-    end
-
-    resolution
+    {:ok, blueprint}
   end
-
-  defp current_operation?(%Operation{current: true}), do: true
-  defp current_operation?(_), do: false
 end

--- a/lib/elixir_boilerplate_graphql/router.ex
+++ b/lib/elixir_boilerplate_graphql/router.ex
@@ -9,10 +9,7 @@ defmodule ElixirBoilerplateGraphQL.Router do
 
     forward("/",
       to: Absinthe.Plug,
-      init_opts: [
-        json_codec: Jason,
-        schema: ElixirBoilerplateGraphQL.Schema
-      ]
+      init_opts: ElixirBoilerplateGraphQL.configuration()
     )
   end
 

--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -1,8 +1,6 @@
 defmodule ElixirBoilerplateGraphQL.Schema do
   use Absinthe.Schema
 
-  alias ElixirBoilerplate.Repo
-
   import_types(Absinthe.Type.Custom)
   import_types(ElixirBoilerplateGraphQL.Application.Types)
 
@@ -17,7 +15,7 @@ defmodule ElixirBoilerplateGraphQL.Schema do
   # end
 
   def context(context) do
-    Map.put(context, :loader, Dataloader.add_source(Dataloader.new(), Repo, Dataloader.Ecto.new(Repo)))
+    Map.put(context, :loader, Dataloader.add_source(Dataloader.new(), :repo, Dataloader.Ecto.new(ElixirBoilerplate.Repo)))
   end
 
   def plugins do
@@ -25,6 +23,6 @@ defmodule ElixirBoilerplateGraphQL.Schema do
   end
 
   def middleware(middleware, _, _) do
-    [NewRelic.Absinthe.Middleware, ElixirBoilerplateGraphQL.Middleware.OperationNameLogger] ++ middleware
+    [NewRelic.Absinthe.Middleware] ++ middleware
   end
 end


### PR DESCRIPTION
## 📖 Description

OperationNameLogger and ErrorReporting are included in pipeline instead of middleware.

Middleware are executed on each field and the pipeline is called 1 time. It makes more sense for logger and errors to be included as pipeline.

## 🦀 Dispatch

- `#dispatch/elixir`
