### PR TITLE
Use :repo instead of ElixirBoilerplate.Repo as dataloader default source key

### DIFF
--- a/lib/elixir_boilerplate_graphql/schema.ex
+++ b/lib/elixir_boilerplate_graphql/schema.ex
@@ -1,8 +1,6 @@
 defmodule ElixirBoilerplateGraphQL.Schema do
   use Absinthe.Schema
 
-  alias ElixirBoilerplate.Repo
-
   import_types(Absinthe.Type.Custom)
   import_types(ElixirBoilerplateGraphQL.Application.Types)
 
@@ -18,7 +16,7 @@ defmodule ElixirBoilerplateGraphQL.Schema do
   # end
 
   def context(context) do
-    Map.put(context, :loader, Dataloader.add_source(Dataloader.new(), Repo, Dataloader.Ecto.new(Repo)))
+    Map.put(context, :loader, Dataloader.add_source(Dataloader.new(), :repo, Dataloader.Ecto.new(ElixirBoilerplate.Repo)))
   end
 
   def plugins do


### PR DESCRIPTION
## 📖 Description

I feel that using `Repo` as the key for our dataloader source add some noise to our `types.ex`. Instead, we should use `:repo`.

Why? Because it requires a useless `alias ElixirBoilerplate.Repo` at the top of every `types.ex` that uses `dataloader`. You could use `ElixirBoilerplate.Repo` directly but once you have 3 or more `dataloader(ElixirBoilerplate.Repo)` `credo` is gonna scream for an alias.

## 🦀 Dispatch

- `#dispatch/elixir`
