### PR TITLE
Add `actions-permissions/monitor` action in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
       MIX_ENV: test
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@main
+      - uses: remi/actions-permissions/monitor@main
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,7 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      - run: apt-get install erlang-ssl --reinstall
+      - uses: GitHubSecurityLab/actions-permissions/monitor@main
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
       MIX_ENV: test
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - run: apt-get install erlang-ssl --reinstall
+
       - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,6 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-
       - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: remi/actions-permissions/monitor@main
+      - run: sudo docker stop
+      - run: sudo docker start
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-monitor-action.yaml
+++ b/.github/workflows/test-monitor-action.yaml
@@ -1,34 +1,23 @@
-name: CI
+name: Test actions-permissions/monitor action
 
 on:
   push:
     branches:
-      - main
-  pull_request:
-    branches:
-      - "**"
+      - feature/add-actions-permissions-monitor-in-ci-workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  ci:
+  test-actions-permissions-monitor-action:
     runs-on: ubuntu-latest
 
-    services:
-      db:
-        image: postgres:14
-        env:
-          POSTGRES_DB: elixir_boilerplate_test
-          POSTGRES_PASSWORD: development
-        ports: ["5432:5432"]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-    env:
-      MIX_ENV: test
-
     steps:
+      - uses: remi/actions-permissions/monitor@main
+      - run: sudo docker stop
+      - run: sudo docker start
+
       - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1
@@ -53,7 +42,4 @@ jobs:
       - run: grep -v '^\(#.*\|\s\?\)$' .env.test >> $GITHUB_ENV
 
       - run: make prepare
-      - run: make check
-      - run: make lint
-      - run: make test
       - run: make build DOCKER_IMAGE_TAG=latest


### PR DESCRIPTION
## 📖 Description

GitHub [recently introduced](https://github.blog/2023-06-26-new-tool-to-secure-your-github-actions) a few actions to monitor action permissions usage.

Let’s use the [monitor action](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor) to track needed permissions.

## 🦀 Dispatch

- `#dispatch/devops`
