### PR TITLE
Fix boilerplate-setup script for GNU find compatibility

### DIFF
--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -31,7 +31,7 @@ content=$(find . -type f \( \
 )
 
 # The identifiers above will be replaced in the path of the files and directories found here
-paths=$(find . -depth 2 \( \
+paths=$(find . -maxdepth 2 \( \
   -path "./lib/${snakeCaseBefore}" -or \
   -path "./lib/${snakeCaseBefore}_*" -or \
   -path "./test/${snakeCaseBefore}" -or \


### PR DESCRIPTION
## 📖 Description

The `-depth` has a different meaning in macOS (BSD) `find` than GNU `find` 🤦‍♂️.

What we really want (that works in both ones) is `-maxdepth`.

## 📓 References

This should fix #338.

## 🦀 Dispatch

- `#dispatch/devops`
