### PR TITLE
Put security plug before everything else in Phoenix endpoint

### DIFF
--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -8,6 +8,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
   socket("/socket", ElixirBoilerplateWeb.Socket)
 
+  plug(ElixirBoilerplateWeb.Plugs.Security)
   plug(:ping)
   plug(:canonical_host)
   plug(:force_ssl)
@@ -49,7 +50,6 @@ defmodule ElixirBoilerplateWeb.Endpoint do
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 
-  plug(ElixirBoilerplateWeb.Plugs.Security)
   plug(ElixirBoilerplateHealth.Router)
   plug(ElixirBoilerplateGraphQL.Router)
   plug(:halt_if_sent)


### PR DESCRIPTION
## 📖 Description

We have a great `Security` plug that uses Phoenix’s [`put_secure_browser_headers/1`](https://hexdocs.pm/phoenix/Phoenix.Controller.html#put_secure_browser_headers/1) to send security-related headers.

However, we end up _not sending them_ in a few cases:

- Ping requests
- Non-canonical host requests
- Static asset requests

Let’s put it at the top of the list.

## 👀 Results

### Before `/ping`

```
$ curl -sI -XGET "http://localhost:4000/ping"
HTTP/1.1 200 OK
cache-control: max-age=0, private, must-revalidate
content-length: 33
content-type: application/json
date: Sat, 08 Jul 2023 01:20:50 GMT
server: Cowboy
```

### After `/ping`

```
$ curl -sI -XGET "http://localhost:4000/ping"
HTTP/1.1 200 OK
cache-control: max-age=0, private, must-revalidate
content-length: 33
content-security-policy: default-src 'none'; form-action 'self'; media-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; font-src 'self'; connect-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self'
content-type: application/json
date: Sat, 08 Jul 2023 01:20:27 GMT
referrer-policy: strict-origin-when-cross-origin
server: Cowboy
x-content-type-options: nosniff
x-download-options: noopen
x-frame-options: SAMEORIGIN
x-permitted-cross-domain-policies: none
```

## 🦀 Dispatch

- `#dispatch/elixir`
