### PR TITLE
Use UUIDs as primary keys instead of sequential integers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,7 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
 
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
   migration_primary_key: [type: :binary_id, default: {:fragment, "gen_random_uuid()"}],
-  migration_timestamps: [type: :utc_datetime],
+  migration_timestamps: [type: :utc_datetime_usec],
   start_apps_before_migration: [:ssl]
 
 config :elixir_boilerplate, Corsica, allow_headers: :all

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,8 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   render_errors: [view: ElixirBoilerplateWeb.Errors.View, accepts: ~w(html json)]
 
 config :elixir_boilerplate, ElixirBoilerplate.Repo,
-  migration_primary_key: [name: :id, type: :binary_id],
+  migration_primary_key: [type: :binary_id, default: {:fragment, "gen_random_uuid()"}],
+  migration_timestamps: [type: :utc_datetime],
   start_apps_before_migration: [:ssl]
 
 config :elixir_boilerplate, Corsica, allow_headers: :all

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,9 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   pubsub_server: ElixirBoilerplate.PubSub,
   render_errors: [view: ElixirBoilerplateWeb.Errors.View, accepts: ~w(html json)]
 
-config :elixir_boilerplate, ElixirBoilerplate.Repo, start_apps_before_migration: [:ssl]
+config :elixir_boilerplate, ElixirBoilerplate.Repo,
+  migration_primary_key: [name: :id, type: :binary_id],
+  start_apps_before_migration: [:ssl]
 
 config :elixir_boilerplate, Corsica, allow_headers: :all
 

--- a/lib/elixir_boilerplate/schema.ex
+++ b/lib/elixir_boilerplate/schema.ex
@@ -1,0 +1,15 @@
+defmodule ElixirBoilerplate.Schema do
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+
+      import Ecto.Changeset
+
+      alias Ecto.{Schema, UUID}
+
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+      @timestamps_opts [type: :utc_datetime_usec]
+    end
+  end
+end


### PR DESCRIPTION
## 📖 Description

⚠️ I am breaking up #249 in smaller chunks to simplify open discussion on the many aspect where our boilerplate project diverted from `phx.new` to realign our use of Phoenix, Absinthe and many libraries with the ongoing effort of the Elixir community.

We are always using `UUID` as primary keys, but since the boilerplate does not inclure any Ecto schema, the groundwork was never migrated back to the template project.

## 📝 Notes

- `use ElixirBoilerplate.Schema` instead of `use Ecto.Schema` in every schema module.
- The new settings on `ElixirBoilerplate.Repo` sets the key type for migrations.

## 🦀 Dispatch

- `#dispatch/elixir`
