### PR TITLE
Switch to setup-buildx-action v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v1
-        id: docker-buildx
-        with:
-          install: true
+      - uses: docker/setup-buildx-action@v2
 
       - uses: erlef/setup-beam@v1
         id: setup-beam


### PR DESCRIPTION
## 📖 Description

Following #168 that was merged this morning, upgrade to the new version of `docker/setup-buildx-action@v2`.

https://github.com/docker/setup-buildx-action

The latest version is `2.9.1` and this will fix multiple warnings we currently have with `v1`:

<img width="1652" alt="Screenshot 2023-08-01 at 15 50 20" src="https://github.com/mirego/elixir-boilerplate/assets/801045/f7848fdc-2afe-43f5-a9b4-6ebda006c701">

## 🦀 Dispatch

- `#dispatch/elixir`
