### PR TITLE
Replace two mix tasks in Dockerfile by a single (existing) one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,7 @@ RUN mix deps.compile
 # Compile assets
 COPY --from=npm-builder /app/assets assets
 COPY priv priv
-RUN mix esbuild default
-RUN mix phx.digest
+RUN mix assets.deploy
 
 # Compile code
 COPY lib lib


### PR DESCRIPTION
## 📖 Description

Instead of using two `mix` assets-related commands in `Dockerfile`, we use the existing `assets.deploy` one!

## 🦀 Dispatch

- `#dispatch/elixir`
