### PR TITLE
Remove DEBUG_ERRORS env var and replace it to true in dev, false in prod

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -12,7 +12,6 @@
 
 # Server configuration
 CORS_ALLOWED_ORIGINS=*
-DEBUG_ERRORS=true
 PORT=4000
 SECRET_KEY_BASE= # Generate secret with `mix phx.gen.secret`
 SESSION_KEY=elixir_boilerplate

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,6 +2,7 @@ import Config
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   code_reloader: true,
+  debug_errors: true,
   check_origin: false,
   watchers: [
     esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]}
@@ -19,3 +20,4 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Plugs.Security, allow_unsafe_sc
 config :logger, :console, format: "[$level] $message\n"
 
 config :phoenix, :stacktrace_depth, 20
+config :phoenix, :plug_init_mode, :runtime

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,6 +2,7 @@ import Config
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
+  debug_errors: false,
   server: true
 
 config :logger, :console,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -21,8 +21,7 @@ config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   session_signing_salt: get_env!("SESSION_SIGNING_SALT"),
   live_view: [signing_salt: get_env!("SESSION_SIGNING_SALT")],
   url: get_endpoint_url_config(canonical_uri),
-  static_url: get_endpoint_url_config(static_uri),
-  debug_errors: get_env("DEBUG_ERRORS", :boolean)
+  static_url: get_endpoint_url_config(static_uri)
 
 config :elixir_boilerplate, Corsica, origins: get_env("CORS_ALLOWED_ORIGINS", :cors)
 


### PR DESCRIPTION
## 📖 Description

Two reasons:

- It’s weird to expose a way in production to see debug errors (potentially leaking sensitive informations)
- It seems that the value is somehow cached in the compile process since changing the value in the env do not change the value when we start the app. This result in a poor experience when all we want to to is set `debug_errors:` to false in dev.

BONUS: While debugging this issue I copied a line we have on another project: https://hexdocs.pm/phoenix/Phoenix.html#plug_init_mode/0

> Returns the :plug_init_mode that controls when plugs are initialized.
> We recommend to set it to :runtime in development for compilation time improvements. It must be :compile in production (the default).


## 🦀 Dispatch

- `#dispatch/elixir`
