### PR TITLE
Add custom body scrubber for Sentry

### DIFF
--- a/lib/elixir_boilerplate/errors/sentry.ex
+++ b/lib/elixir_boilerplate/errors/sentry.ex
@@ -1,0 +1,41 @@
+defmodule ElixirBoilerplate.Errors.Sentry do
+  @moduledoc false
+  @scrubbed_keys ["first_name", "last_name", "email"]
+  @scrubbed_value "*********"
+
+  def scrub_params(conn) do
+    conn
+    |> Sentry.PlugContext.default_body_scrubber()
+    |> scrub_map(@scrubbed_keys)
+  end
+
+  def scrubbed_remote_address(_conn), do: @scrubbed_value
+
+  # Reference: https://github.com/getsentry/sentry-elixir/blob/9.1.0/lib/sentry/plug_context.ex#L232
+  defp scrub_map(map, scrubbed_keys) do
+    Map.new(map, fn {key, value} ->
+      value =
+        cond do
+          key in scrubbed_keys -> @scrubbed_value
+          is_struct(value) -> value |> Map.from_struct() |> scrub_map(scrubbed_keys)
+          is_map(value) -> scrub_map(value, scrubbed_keys)
+          is_list(value) -> scrub_list(value, scrubbed_keys)
+          true -> value
+        end
+
+      {key, value}
+    end)
+  end
+
+  # Reference: https://github.com/getsentry/sentry-elixir/blob/9.1.0/lib/sentry/plug_context.ex#L248
+  defp scrub_list(list, scrubbed_keys) do
+    Enum.map(list, fn value ->
+      cond do
+        is_struct(value) -> value |> Map.from_struct() |> scrub_map(scrubbed_keys)
+        is_map(value) -> scrub_map(value, scrubbed_keys)
+        is_list(value) -> scrub_list(value, scrubbed_keys)
+        true -> value
+      end
+    end)
+  end
+end

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -47,7 +47,11 @@ defmodule ElixirBoilerplateWeb.Endpoint do
     json_decoder: Phoenix.json_library()
   )
 
-  plug(Sentry.PlugContext, body_scrubber: {ElixirBoilerplate.Errors.Sentry, :scrub_params}, remote_address_reader: {ElixirBoilerplate.Errors.Sentry, :scrubbed_remote_address})
+  plug(Sentry.PlugContext,
+    body_scrubber: {ElixirBoilerplate.Errors.Sentry, :scrub_params},
+    remote_address_reader: {ElixirBoilerplate.Errors.Sentry, :scrubbed_remote_address}
+  )
+
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -47,7 +47,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
     json_decoder: Phoenix.json_library()
   )
 
-  plug(Sentry.PlugContext)
+  plug(Sentry.PlugContext, body_scrubber: {ElixirBoilerplate.Errors.Sentry, :scrub_params}, remote_address_reader: {ElixirBoilerplate.Errors.Sentry, :scrubbed_remote_address})
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 


### PR DESCRIPTION
## 📖 Description

This pull request introduces a custom body scrubber to mask sensitive information before sending it to Sentry. While the default body scrubber already includes common terms like `["password", "passwd", "secret"]`, there are scenarios where additional information needs to be hidden.

## 🦀 Dispatch

- `#dispatch/elixir`
