### PR TITLE
Add graphiql warning comment

### DIFF
--- a/lib/elixir_boilerplate_graphql/router.ex
+++ b/lib/elixir_boilerplate_graphql/router.ex
@@ -19,6 +19,8 @@ defmodule ElixirBoilerplateGraphQL.Router do
   plug(:match)
   plug(:dispatch)
 
+  # It is intentional that we do not *serve* GraphiQL as part of the API.
+  # Developers should use standalone GraphQL clients that connect to the API instead.
   forward("/graphql", to: GraphQL)
 
   match(_, do: conn)


### PR DESCRIPTION
## 📖 Description

Adds a comment in the graphql router to make our stance on `/graphiql` more explicit for future devs.

## 📓 References

https://app.escape.tech/scan/d37e1571-d2a0-471f-b351-abd4c74afb5d/issues/?alert=7bea644f-7ea2-4032-9841-ada3855d290e

## 🦀 Dispatch

- `#dispatch/elixir`
