### PR TITLE
Halt server if migrations fail on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,12 +79,12 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-WORKDIR "/opt/elixir_boilerplate"
-RUN chown nobody /opt/elixir_boilerplate
+WORKDIR "/app"
+RUN chown nobody /app
 
 # Only copy the final release from the build stage
 COPY --from=otp-builder --chown=nobody:root /app/_build/prod/rel/elixir_boilerplate ./
 
 USER nobody
 
-CMD ["/opt/elixir_boilerplate/bin/server"]
+CMD ["sh", "-c", "/app/bin/migrate && /app/bin/server"]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,8 +2,7 @@ import Config
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
-  debug_errors: false,
-  server: true
+  debug_errors: false
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -14,8 +14,13 @@ config :elixir_boilerplate, ElixirBoilerplate.Repo,
   pool_size: get_env!("DATABASE_POOL_SIZE", :integer),
   socket_options: if(get_env("DATABASE_IPV6", :boolean), do: [:inet6], else: [])
 
+# NOTE: Only set `server` to `true` if `PHX_SERVER` is present. We cannot set
+# it to `false` otherwise because `mix phx.server` will stop working without it.
+if get_env("PHX_SERVER", :boolean) == true do
+  config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint, server: true
+end
+
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
-  server: get_env("PHX_SERVER", :boolean),
   http: [port: get_env!("PORT", :integer)],
   secret_key_base: get_env!("SECRET_KEY_BASE"),
   session_key: get_env!("SESSION_KEY"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,6 +15,7 @@ config :elixir_boilerplate, ElixirBoilerplate.Repo,
   socket_options: if(get_env("DATABASE_IPV6", :boolean), do: [:inet6], else: [])
 
 config :elixir_boilerplate, ElixirBoilerplateWeb.Endpoint,
+  server: get_env("PHX_SERVER", :boolean),
   http: [port: get_env!("PORT", :integer)],
   secret_key_base: get_env!("SECRET_KEY_BASE"),
   session_key: get_env!("SESSION_KEY"),

--- a/rel/overlays/bin/migrate
+++ b/rel/overlays/bin/migrate
@@ -1,4 +1,3 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
-
 exec ./elixir_boilerplate eval ElixirBoilerplate.Release.migrate

--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,7 +1,3 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
-
-# Always run migrations
-./elixir_boilerplate eval ElixirBoilerplate.Release.migrate
-
-exec ./elixir_boilerplate start
+PHX_SERVER=true exec ./elixir_boilerplate start


### PR DESCRIPTION
## 📖 Description

It doesn’t make much sense to start the server if the migrations (that are run on container startup) fail.

## 📝 Notes

I also updated a few lines based on the [`mix phx.gen.release --docker`](https://github.com/phoenixframework/phoenix/tree/main/priv/templates/phx.gen.release) template.

## 🦀 Dispatch

- `#dispatch/elixir`
