### PR TITLE
Restrict graphql content types

### DIFF
--- a/lib/elixir_boilerplate_graphql/router.ex
+++ b/lib/elixir_boilerplate_graphql/router.ex
@@ -5,6 +5,13 @@ defmodule ElixirBoilerplateGraphQL.Router do
     @moduledoc false
     use Plug.Router
 
+    plug(
+      Plug.Parsers,
+      parsers: [:json],
+      pass: [],
+      json_decoder: Phoenix.json_library()
+    )
+
     plug(:match)
     plug(:dispatch)
 

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -4,7 +4,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
   alias Plug.Conn
 
-  @plug_ssl Plug.SSL.init(rewrite_on: [:x_forwarded_proto])
+  @plug_ssl Plug.SSL.init(rewrite_on: [:x_forwarded_proto], subdomains: true)
 
   socket("/socket", ElixirBoilerplateWeb.Socket)
   socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: {ElixirBoilerplateWeb.Session, :config, []}]])

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -40,13 +40,6 @@ defmodule ElixirBoilerplateWeb.Endpoint do
   plug(Plug.RequestId)
   plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
 
-  plug(
-    Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
-    pass: ["*/*"],
-    json_decoder: Phoenix.json_library()
-  )
-
   plug(Sentry.PlugContext,
     body_scrubber: {ElixirBoilerplate.Errors.Sentry, :scrub_params},
     remote_address_reader: {ElixirBoilerplate.Errors.Sentry, :scrubbed_remote_address}

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -4,7 +4,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
   alias Plug.Conn
 
-  @plug_ssl Plug.SSL.init(rewrite_on: [:x_forwarded_proto], subdomains: true)
+  @plug_ssl Plug.SSL.init(rewrite_on: [:x_forwarded_proto])
 
   socket("/socket", ElixirBoilerplateWeb.Socket)
   socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: {ElixirBoilerplateWeb.Session, :config, []}]])

--- a/lib/elixir_boilerplate_web/router.ex
+++ b/lib/elixir_boilerplate_web/router.ex
@@ -4,6 +4,13 @@ defmodule ElixirBoilerplateWeb.Router do
   import Phoenix.LiveView.Router
 
   pipeline :browser do
+    plug(
+      Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Phoenix.json_library()
+    )
+
     plug(:accepts, ["html", "json"])
 
     plug(:session)


### PR DESCRIPTION
## 📖 Description

Restrict the allowed graphql content-types to only `application/json`

Also, include subdomains in the HSTS header as recommended by Escape, to apply the Strict-Transport-Security rule to the site's subdomains as well.

## 🦀 Dispatch

- `#dispatch/elixir`
