### PR TITLE
Include subdomains in hsts rule

### DIFF
--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -4,7 +4,7 @@ defmodule ElixirBoilerplateWeb.Endpoint do
 
   alias Plug.Conn
 
-  @plug_ssl Plug.SSL.init(rewrite_on: [:x_forwarded_proto])
+  @plug_ssl Plug.SSL.init(rewrite_on: [:x_forwarded_proto], subdomains: true)
 
   socket("/socket", ElixirBoilerplateWeb.Socket)
   socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: {ElixirBoilerplateWeb.Session, :config, []}]])


### PR DESCRIPTION
## 📖 Description

Include subdomains in the HSTS header as recommended by Escape, to apply the Strict-Transport-Security rule to the site's subdomains as well. 

## 📝 Notes

Background info:
HSTS is a response header that informs the browser that it should never load a site using HTTP and should automatically convert all attempts to access the site using HTTP to HTTPS requests instead. 
It can be used in addition to redirection from http to https. 

Plug.SSL sets the hsts response header by default, but does not include subdomains by default.

Relevant doc: 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
https://hexdocs.pm/plug/Plug.SSL.html


## 🦀 Dispatch

- `#dispatch/elixir`
