### PR TITLE
Sort keys in format_bindings/1

### DIFF
--- a/test/elixir_boilerplate_web/errors_test.exs
+++ b/test/elixir_boilerplate_web/errors_test.exs
@@ -68,9 +68,9 @@ defmodule ElixirBoilerplateWeb.ErrorsTest do
       |> changeset_to_error_messages()
 
     assert html =~ "<li>email has invalid format[validation=:format]</li>"
-    assert html =~ "<li>email should be %{count} character(s)[count=10,type=:string,kind=:is,validation=:length]</li>"
+    assert html =~ "<li>email should be %{count} character(s)[count=10,kind=:is,type=:string,validation=:length]</li>"
     assert html =~ "<li>multiple_roles.type can&#39;t be blank[validation=:required]</li>"
-    assert html =~ "<li>nicknames should have at least %{count} item(s)[count=1,type=:list,kind=:min,validation=:length]</li>"
+    assert html =~ "<li>nicknames should have at least %{count} item(s)[count=1,kind=:min,type=:list,validation=:length]</li>"
     assert html =~ "<li>single_role.type is invalid[enum=admin,moderator,member,validation=:inclusion]</li>"
   end
 

--- a/test/support/gettext_interpolation.ex
+++ b/test/support/gettext_interpolation.ex
@@ -16,6 +16,8 @@ defmodule ElixirBoilerplate.GettextInterpolation do
   {:ok, "test[arg=:atom]"}
   iex> runtime_interpolate("test", %{arg: [:atom,:atom2]})
   {:ok, "test[arg=:atom,:atom2]"}
+  iex> runtime_interpolate("test", %{b: 1, a: [:a, :b]})
+  {:ok, "test[a=:a,:b,b=1]"}
   """
   @impl true
   def runtime_interpolate(message, bindings), do: {:ok, format(message, bindings)}
@@ -35,7 +37,11 @@ defmodule ElixirBoilerplate.GettextInterpolation do
   defp format_bindings(bindings) when is_map(bindings) and map_size(bindings) === 0, do: ""
 
   defp format_bindings(bindings) when is_map(bindings) do
-    bindings = Enum.map_join(bindings, ",", fn {key, value} -> "#{key}=#{format_value(value)}" end)
+    bindings =
+      bindings
+      |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)
+      |> Enum.map_join(",", fn {key, value} -> "#{key}=#{format_value(value)}" end)
+
     "[#{bindings}]"
   end
 


### PR DESCRIPTION
## 📖 Description

Tests were failing when the left side's key order differed from the right side's. Explicitly ordering the keys makes the test less flaky. 

## 📝 Notes

Added a doctest to test the ordering.

## 📓 References

N/A

## 🦀 Dispatch

- `#dispatch/elixir`
