### PR TITLE
Revert "Restrict graphql content types (#458)"

### DIFF
--- a/lib/elixir_boilerplate_graphql/router.ex
+++ b/lib/elixir_boilerplate_graphql/router.ex
@@ -5,13 +5,6 @@ defmodule ElixirBoilerplateGraphQL.Router do
     @moduledoc false
     use Plug.Router
 
-    plug(
-      Plug.Parsers,
-      parsers: [:json],
-      pass: [],
-      json_decoder: Phoenix.json_library()
-    )
-
     plug(:match)
     plug(:dispatch)
 

--- a/lib/elixir_boilerplate_web/endpoint.ex
+++ b/lib/elixir_boilerplate_web/endpoint.ex
@@ -40,6 +40,13 @@ defmodule ElixirBoilerplateWeb.Endpoint do
   plug(Plug.RequestId)
   plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
 
+  plug(
+    Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+  )
+
   plug(Sentry.PlugContext,
     body_scrubber: {ElixirBoilerplate.Errors.Sentry, :scrub_params},
     remote_address_reader: {ElixirBoilerplate.Errors.Sentry, :scrubbed_remote_address}

--- a/lib/elixir_boilerplate_web/router.ex
+++ b/lib/elixir_boilerplate_web/router.ex
@@ -4,13 +4,6 @@ defmodule ElixirBoilerplateWeb.Router do
   import Phoenix.LiveView.Router
 
   pipeline :browser do
-    plug(
-      Plug.Parsers,
-      parsers: [:urlencoded, :multipart, :json],
-      pass: ["*/*"],
-      json_decoder: Phoenix.json_library()
-    )
-
     plug(:accepts, ["html", "json"])
 
     plug(:session)


### PR DESCRIPTION
This reverts commit 6a4173ac3f106fc68a069905b0fb84191020e9ff.

## 📖 Description

We unfortunately cannot remove the `Plug.Parser` from endpoint since the plug `Plug.MethodOverride` requires the body to be parsed before calling it. I've tried to move the plug `MethodOverride` to `router.ex` but unfortunately it doesn't work since a pipeline is only executed if a route matches. 

In the documentation:
```
Note that router pipelines are only invoked after a route is found. No plug is invoked in case no matches were found.
```

For now we revert this commit and we can check after what is the best way to restrict the GraphQL endpoint to only json.

## 📝 Notes

<!-- Any additional notes that might be helpful for reviewers? -->

## 📓 References

<!-- Does this pull request fix any reported issue (eg. `Fixes #34`) in this repository? -->

## 🦀 Dispatch

- `#dispatch/elixir`
