### PR TITLE
Enable observer in dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,12 +24,15 @@ defmodule ElixirBoilerplate.Mixfile do
   def application do
     [
       mod: {ElixirBoilerplate.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: extra_applications(Mix.env()) ++ [:logger, :runtime_tools]
     ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
+
+  defp extra_applications(:dev), do: [:observer, :wx]
+  defp extra_applications(_), do: []
 
   defp aliases do
     [


### PR DESCRIPTION
I used [the same pattern phoenix does](https://github.com/phoenixframework/phoenix/blob/v1.8.1/mix.exs#L62-L68)